### PR TITLE
Respect website scoped config for order export status

### DIFF
--- a/Controller/Adminhtml/Order/Export.php
+++ b/Controller/Adminhtml/Order/Export.php
@@ -65,7 +65,7 @@ class Export extends \Magento\Backend\App\Action
             }
 
             // Check whether order exports are enabled.
-            if ( ! $this->_exportHelper->isEnabled($order->getStore()->getWebsiteId())) {
+            if ( ! $this->_exportHelper->isEnabled($this->_getWebsiteId($order))) {
                 $this->messageManager->addError(__('Order exports are currently disabled. Please review the OrderFlow module configuration.'));
                 return $resultRedirect->setRefererUrl();
             }

--- a/Controller/Adminhtml/Order/Export.php
+++ b/Controller/Adminhtml/Order/Export.php
@@ -57,16 +57,16 @@ class Export extends \Magento\Backend\App\Action
     {
         $resultRedirect = $this->resultRedirectFactory->create();
 
-        // Check whether order exports are enabled.
-        if ( ! $this->_exportHelper->isEnabled()) {
-            $this->messageManager->addError(__('Order exports are currently disabled. Please review the OrderFlow module configuration.'));
-            return $resultRedirect->setRefererUrl();
-        }
-
         try {
             $order = $this->_getOrder();
 
             if ( ! $order) {
+                return $resultRedirect->setRefererUrl();
+            }
+
+            // Check whether order exports are enabled.
+            if ( ! $this->_exportHelper->isEnabled($order->getStore()->getWebsiteId())) {
+                $this->messageManager->addError(__('Order exports are currently disabled. Please review the OrderFlow module configuration.'));
                 return $resultRedirect->setRefererUrl();
             }
 

--- a/Model/Service/Export/Exporter.php
+++ b/Model/Service/Export/Exporter.php
@@ -38,7 +38,7 @@ class Exporter
      */
     public function export(\RealtimeDespatch\OrderFlow\Model\Request $request)
     {
-        if ( ! $this->_type->isEnabled($request->getScopeId()) && $this->_type::TYPE != 'Product') {
+        if ( ! $this->_type->isEnabled($request->getScopeId()) && !in_array($this->_type::TYPE, ['Product', 'Order'])) {
             throw new \Exception($this->_type->getType().' exports are currently disabled. Please review your OrderFlow module configuration.');
         }
 

--- a/Model/Service/Export/Type/OrderExportExporterType.php
+++ b/Model/Service/Export/Type/OrderExportExporterType.php
@@ -108,6 +108,13 @@ class OrderExportExporterType extends \RealtimeDespatch\OrderFlow\Model\Service\
             if ( ! $order->getId()) {
                 throw new \Exception('Order #'.$incrementId.' does not exist.');
             }
+            $websiteId = $order->getStore()->getWebsiteId();
+            if (!$this->isEnabled($websiteId)) {
+                throw new \Exception(
+                    "Order exports are disabled for website ID '{$websiteId}'. " .
+                            "Please review your OrderFlow module configuration."
+                );
+            }
 
             $order->setOrderflowExportStatus(__('Exported'));
             $order->setOrderflowExportDate($request->getCreationTime());

--- a/Plugin/Adminhtml/OrderCancellation.php
+++ b/Plugin/Adminhtml/OrderCancellation.php
@@ -54,7 +54,7 @@ class OrderCancellation
      */
     public function beforeCancel(\Magento\Sales\Model\Order $subject)
     {
-        if ( ! $this->_helper->isEnabled()) {
+        if ( ! $this->_helper->isEnabled($subject->getStore()->getWebsiteId())) {
             throw new Exception(__('Order exports are currently disabled. Please review the OrderFlow module configuration.'));
         }
 


### PR DESCRIPTION
Existing code required order exports to be globally enabled to work. 
These changes ensure that the website ID of the order being exported is respected.