### PR TITLE
Add product export endpoint with ability to output attribute option labels instead of IDs

### DIFF
--- a/Api/Data/ProductInterface.php
+++ b/Api/Data/ProductInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace RealtimeDespatch\OrderFlow\Api\Data;
+
+/**
+ * Product export data interface.
+ *
+ * @api
+ */
+interface ProductInterface extends \Magento\Catalog\Api\Data\ProductInterface
+{
+    /**
+     * Get attribute set name.
+     *
+     * @return string|null
+     */
+    public function getAttributeSetName();
+
+    /**
+     * Set attribute set name.
+     *
+     * @param string $attributeSetName
+     *
+     * @return \RealtimeDespatch\OrderFlow\Api\Data\ProductInterface
+     */
+    public function setAttributeSetName($attributeSetName);
+}

--- a/Api/ProductRepositoryInterface.php
+++ b/Api/ProductRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace RealtimeDespatch\OrderFlow\Api;
+
+/**
+ * Product export repository interface.
+ *
+ * @api
+ */
+interface ProductRepositoryInterface
+{
+    /**
+     * Get info about product by SKU.
+     *
+     * @param string $sku
+     * @param int|null $storeId
+     *
+     * @return \RealtimeDespatch\OrderFlow\Api\Data\ProductInterface
+     */
+    public function get($sku, $storeId = null);
+}

--- a/Helper/Export/Order.php
+++ b/Helper/Export/Order.php
@@ -11,6 +11,7 @@ class Order extends \Magento\Framework\App\Helper\AbstractHelper
 {
     const STATUS_PENDING = 'Pending';
     const STATUS_QUEUED = 'Queued';
+    const STATUS_EXPORTED = 'Exported';
 
     /**
      * @var \Mage\Sales\Model\OrderFactory
@@ -132,7 +133,7 @@ class Order extends \Magento\Framework\App\Helper\AbstractHelper
             ->addFieldToFilter('is_virtual', ['eq' => 0])
             ->addFieldToFilter('orderflow_export_date', ['null' => true])
             ->addFieldToFilter('orderflow_export_status', [
-                ['nin' => [self::STATUS_QUEUED, 'Exported']],
+                ['nin' => [self::STATUS_QUEUED, self::STATUS_EXPORTED]],
                 ['null' => true],
             ])
             ->setPage(1, $this->getBatchSize($website->getId()));

--- a/Model/Data/Product.php
+++ b/Model/Data/Product.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace RealtimeDespatch\OrderFlow\Model\Data;
+
+use RealtimeDespatch\OrderFlow\Api\Data\ProductInterface;
+
+/**
+ * Product export data object.
+ *
+ * @api
+ */
+class Product extends \Magento\Catalog\Model\Product implements ProductInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function getAttributeSetName()
+    {
+        return $this->getData('attribute_set_name');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setAttributeSetName($attributeSetName)
+    {
+        return $this->setData('attribute_set_name', $attributeSetName);
+    }
+}

--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace RealtimeDespatch\OrderFlow\Model;
+
+use Magento\Catalog\Api\AttributeSetRepositoryInterface;
+use Magento\Catalog\Api\ProductAttributeManagementInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface as CatalogProductRepositoryInterface;
+use Magento\Eav\Api\AttributeRepositoryInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\ObjectManagerInterface;
+use RealtimeDespatch\OrderFlow\Api\ProductRepositoryInterface;
+
+/**
+ * OrderFlow product export repository.
+ */
+class ProductRepository implements ProductRepositoryInterface
+{
+    private const XML_PATH_USE_ATTRIBUTE_OPTION_LABELS = 'orderflow_product_export/settings/use_attribute_option_labels';
+
+    /**
+     * @var CatalogProductRepositoryInterface
+     */
+    protected $catalogProductRepository;
+
+    /**
+     * @var AttributeRepositoryInterface
+     */
+    protected $attributeRepository;
+
+    /**
+     * @var AttributeSetRepositoryInterface
+     */
+    protected $attributeSetRepository;
+
+    /**
+     * @var ProductAttributeManagementInterface
+     */
+    protected $productAttributeManagement;
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    /**
+     * @var array
+     */
+    protected $attributeOptionsMap = [];
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * @param CatalogProductRepositoryInterface $catalogProductRepository
+     * @param AttributeRepositoryInterface $attributeRepository
+     * @param AttributeSetRepositoryInterface $attributeSetRepository
+     * @param ProductAttributeManagementInterface $productAttributeManagement
+     * @param ObjectManagerInterface $objectManager
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        CatalogProductRepositoryInterface $catalogProductRepository,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeSetRepositoryInterface $attributeSetRepository,
+        ProductAttributeManagementInterface $productAttributeManagement,
+        ObjectManagerInterface $objectManager,
+        ScopeConfigInterface $scopeConfig
+    ) {
+        $this->catalogProductRepository = $catalogProductRepository;
+        $this->attributeRepository = $attributeRepository;
+        $this->attributeSetRepository = $attributeSetRepository;
+        $this->productAttributeManagement = $productAttributeManagement;
+        $this->objectManager = $objectManager;
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function get($sku, $storeId = null)
+    {
+        $product = $this->catalogProductRepository->get($sku, false, $storeId);
+        $attributeSet = $this->attributeSetRepository->get($product->getAttributeSetId());
+
+        if ($this->shouldUseAttributeOptionLabels()) {
+            $attributes = $this->productAttributeManagement->getAttributes($product->getAttributeSetId());
+
+            $sourceModelAttributes = array_filter($attributes, function ($attribute) {
+                return sizeof($attribute->getOptions()) > 0;
+            });
+
+            foreach ($sourceModelAttributes as $attribute) {
+                $attributeOptions = $this->getAttributeOptionsMap($attribute->getAttributeCode());
+                $value = $product->getData($attribute->getAttributeCode());
+
+                if ($attribute->getFrontendInput() == 'multiselect' && is_string($value)) {
+                    $value = explode(',', $value);
+                }
+
+                if (is_array($value)) {
+                    $newValue = [];
+                    foreach ($value as $optionValue) {
+                        $newValue[] = $attributeOptions[$optionValue] ?? $optionValue;
+                    }
+                    $product->setCustomAttribute($attribute->getAttributeCode(), $newValue);
+                } else {
+                    $product->setCustomAttribute($attribute->getAttributeCode(), $attributeOptions[$value] ?? $value);
+                }
+            }
+        }
+
+        $exportProduct = $this->objectManager->create(\RealtimeDespatch\OrderFlow\Model\Data\Product::class);
+        $exportProduct->setData($product->getData());
+        foreach ($product->getCustomAttributes() as $attributeCode => $customAttribute) {
+            if (is_object($customAttribute) && method_exists($customAttribute, 'getAttributeCode')) {
+                $attributeCode = $customAttribute->getAttributeCode();
+            }
+            if (!is_string($attributeCode) || $attributeCode === '') {
+                continue;
+            }
+            $value = $customAttribute;
+            if (is_object($customAttribute) && method_exists($customAttribute, 'getValue')) {
+                $value = $customAttribute->getValue();
+            }
+            $exportProduct->setCustomAttribute($attributeCode, $value);
+        }
+        if ($product->getExtensionAttributes() !== null) {
+            $exportProduct->setExtensionAttributes($product->getExtensionAttributes());
+        }
+        $exportProduct->setAttributeSetName($attributeSet->getAttributeSetName());
+
+        return $exportProduct;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function shouldUseAttributeOptionLabels()
+    {
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_USE_ATTRIBUTE_OPTION_LABELS);
+    }
+
+    /**
+     * @param string $attributeCode
+     *
+     * @return array
+     */
+    protected function getAttributeOptionsMap($attributeCode)
+    {
+        if (!isset($this->attributeOptionsMap[$attributeCode])) {
+            $attribute = $this->attributeRepository->get('catalog_product', $attributeCode);
+            $options = [];
+            foreach ($attribute->getOptions() as $option) {
+                $options[$option->getValue()] = (string)$option->getLabel();
+            }
+            $this->attributeOptionsMap[$attributeCode] = $options;
+        }
+
+        return $this->attributeOptionsMap[$attributeCode];
+    }
+}

--- a/Plugin/Webapi/Soap/ProductExport.php
+++ b/Plugin/Webapi/Soap/ProductExport.php
@@ -5,6 +5,7 @@ namespace RealtimeDespatch\OrderFlow\Plugin\Webapi\Soap;
 class ProductExport
 {
     const OP_PRODUCT_EXPORT = 'catalogProductRepositoryV1Get';
+    const OP_ORDERFLOW_PRODUCT_EXPORT = 'realtimeDespatchOrderFlowProductRepositoryV1Get';
 
     /**
      * @var \Magento\Framework\ObjectManagerInterface
@@ -65,7 +66,7 @@ class ProductExport
      */
     protected function _isProductExport($operation)
     {
-        return $operation === self::OP_PRODUCT_EXPORT;
+        return in_array($operation, [self::OP_PRODUCT_EXPORT, self::OP_ORDERFLOW_PRODUCT_EXPORT], true);
     }
 
     /**

--- a/Test/Unit/Model/Indexer/ProductReindexerTest.php
+++ b/Test/Unit/Model/Indexer/ProductReindexerTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Indexer;
+
+use Magento\Catalog\Model\ResourceModel\Product as ProductResourceModel;
+use Magento\Framework\Indexer\IndexerInterface;
+use Magento\Framework\Indexer\IndexerRegistry;
+use Magento\Framework\Module\Manager;
+use PHPUnit\Framework\TestCase;
+use RealtimeDespatch\OrderFlow\Model\Indexer\ProductReindexer;
+
+class ProductReindexerTest extends TestCase
+{
+    private Manager $moduleManager;
+    private IndexerRegistry $indexerRegistry;
+    private ProductResourceModel $productResource;
+    private ProductReindexer $reindexer;
+
+    protected function setUp(): void
+    {
+        $this->moduleManager = $this->createMock(Manager::class);
+        $this->indexerRegistry = $this->createMock(IndexerRegistry::class);
+        $this->productResource = $this->createMock(ProductResourceModel::class);
+
+        $this->reindexer = new ProductReindexer(
+            $this->moduleManager,
+            $this->indexerRegistry,
+            $this->productResource
+        );
+    }
+
+    public function testReindexSkusReturnsEarlyForEmptySkuList(): void
+    {
+        $this->moduleManager->expects($this->never())->method('isEnabled');
+        $this->productResource->expects($this->never())->method('getProductsIdsBySkus');
+
+        $this->reindexer->reindexSkus([]);
+    }
+
+    public function testReindexSkusReturnsEarlyWhenMsiIsDisabled(): void
+    {
+        $this->moduleManager
+            ->expects($this->once())
+            ->method('isEnabled')
+            ->with('Magento_InventoryApi')
+            ->willReturn(false);
+
+        $this->productResource->expects($this->never())->method('getProductsIdsBySkus');
+
+        $this->reindexer->reindexSkus(['ABC123']);
+    }
+
+    public function testReindexSkusReturnsEarlyWhenNoProductsAreResolved(): void
+    {
+        $this->moduleManager
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $this->productResource
+            ->expects($this->once())
+            ->method('getProductsIdsBySkus')
+            ->with(['ABC123'])
+            ->willReturn([]);
+
+        $this->indexerRegistry->expects($this->never())->method('get');
+
+        $this->reindexer->reindexSkus(['ABC123']);
+    }
+
+    public function testReindexSkusReindexesResolvedIdsAcrossAllIndexers(): void
+    {
+        $catalogInventoryIndexer = $this->createMock(IndexerInterface::class);
+        $catalogPriceIndexer = $this->createMock(IndexerInterface::class);
+        $catalogSearchIndexer = $this->createMock(IndexerInterface::class);
+
+        $this->moduleManager
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $this->productResource
+            ->expects($this->once())
+            ->method('getProductsIdsBySkus')
+            ->with(['ABC123', 'DEF456'])
+            ->willReturn([
+                'ABC123' => '10',
+                'DEF456' => 20,
+            ]);
+
+        $this->indexerRegistry
+            ->expects($this->exactly(3))
+            ->method('get')
+            ->willReturnMap([
+                ['cataloginventory_stock', $catalogInventoryIndexer],
+                ['catalog_product_price', $catalogPriceIndexer],
+                ['catalogsearch_fulltext', $catalogSearchIndexer],
+            ]);
+
+        $catalogInventoryIndexer
+            ->expects($this->once())
+            ->method('reindexList')
+            ->with([10, 20]);
+
+        $catalogPriceIndexer
+            ->expects($this->once())
+            ->method('reindexList')
+            ->with([10, 20]);
+
+        $catalogSearchIndexer
+            ->expects($this->once())
+            ->method('reindexList')
+            ->with([10, 20]);
+
+        $this->reindexer->reindexSkus(['ABC123', 'ABC123', 'DEF456']);
+    }
+}

--- a/Test/Unit/Model/ProductRepositoryTest.php
+++ b/Test/Unit/Model/ProductRepositoryTest.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model;
+
+use Magento\Catalog\Api\AttributeSetRepositoryInterface;
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
+use Magento\Catalog\Api\Data\ProductCustomOptionInterface;
+use Magento\Catalog\Api\ProductAttributeManagementInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface as CatalogProductRepositoryInterface;
+use Magento\Eav\Api\AttributeRepositoryInterface;
+use Magento\Eav\Api\Data\AttributeOptionInterface;
+use Magento\Eav\Api\Data\AttributeSetInterface;
+use Magento\Framework\Api\AttributeValue;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\ObjectManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RealtimeDespatch\OrderFlow\Model\Data\Product;
+use RealtimeDespatch\OrderFlow\Model\ProductRepository;
+
+class ProductRepositoryTest extends TestCase
+{
+    /**
+     * @var CatalogProductRepositoryInterface&MockObject
+     */
+    private $catalogProductRepository;
+
+    /**
+     * @var AttributeRepositoryInterface&MockObject
+     */
+    private $attributeRepository;
+
+    /**
+     * @var AttributeSetRepositoryInterface&MockObject
+     */
+    private $attributeSetRepository;
+
+    /**
+     * @var ProductAttributeManagementInterface&MockObject
+     */
+    private $productAttributeManagement;
+
+    /**
+     * @var ObjectManagerInterface&MockObject
+     */
+    private $objectManager;
+
+    /**
+     * @var ScopeConfigInterface&MockObject
+     */
+    private $scopeConfig;
+
+    /**
+     * @var ProductRepository
+     */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        $this->catalogProductRepository = $this->createMock(CatalogProductRepositoryInterface::class);
+        $this->attributeRepository = $this->createMock(AttributeRepositoryInterface::class);
+        $this->attributeSetRepository = $this->createMock(AttributeSetRepositoryInterface::class);
+        $this->productAttributeManagement = $this->createMock(ProductAttributeManagementInterface::class);
+        $this->objectManager = $this->createMock(ObjectManagerInterface::class);
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+
+        $this->repository = new ProductRepository(
+            $this->catalogProductRepository,
+            $this->attributeRepository,
+            $this->attributeSetRepository,
+            $this->productAttributeManagement,
+            $this->objectManager,
+            $this->scopeConfig
+        );
+    }
+
+    public function testGetReturnsMappedOptionLabelsAndAttributeSetName(): void
+    {
+        $product = $this->createMock(\Magento\Catalog\Model\Product::class);
+        $exportProduct = $this->createMock(Product::class);
+        $colorAttribute = $this->createConfiguredMock(ProductAttributeInterface::class, [
+            'getAttributeCode' => 'color',
+            'getFrontendInput' => 'select',
+            'getOptions' => [$this->createMock(ProductCustomOptionInterface::class)],
+        ]);
+        $materialAttribute = $this->createConfiguredMock(ProductAttributeInterface::class, [
+            'getAttributeCode' => 'material',
+            'getFrontendInput' => 'multiselect',
+            'getOptions' => [$this->createMock(ProductCustomOptionInterface::class)],
+        ]);
+        $attributeSet = $this->createConfiguredMock(AttributeSetInterface::class, [
+            'getAttributeSetName' => 'Fabric',
+        ]);
+
+        $colorOptions = [
+            $this->createOption('12', 'Blue'),
+        ];
+        $materialOptions = [
+            $this->createOption('5', 'Cotton'),
+            $this->createOption('7', 'Linen'),
+        ];
+
+        $this->catalogProductRepository->expects($this->once())
+            ->method('get')
+            ->with('SKU-1', false, null)
+            ->willReturn($product);
+        $this->scopeConfig->expects($this->once())
+            ->method('isSetFlag')
+            ->with('orderflow_product_export/settings/use_attribute_option_labels')
+            ->willReturn(true);
+        $product->method('getAttributeSetId')->willReturn(42);
+        $this->productAttributeManagement->expects($this->once())
+            ->method('getAttributes')
+            ->with(42)
+            ->willReturn([$colorAttribute, $materialAttribute]);
+        $this->attributeSetRepository->expects($this->once())
+            ->method('get')
+            ->with(42)
+            ->willReturn($attributeSet);
+        $this->attributeRepository->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnMap([
+                ['catalog_product', 'color', $this->createAttributeWithOptions($colorOptions)],
+                ['catalog_product', 'material', $this->createAttributeWithOptions($materialOptions)],
+            ]);
+        $product->method('getData')
+            ->willReturnCallback(function (...$args) {
+                $key = $args[0] ?? null;
+                if ($key === 'color') {
+                    return '12';
+                }
+                if ($key === 'material') {
+                    return '5,7';
+                }
+                if ($key === null) {
+                    return ['sku' => 'SKU-1', 'attribute_set_id' => 42];
+                }
+
+                return null;
+            });
+        $product->expects($this->exactly(2))
+            ->method('setCustomAttribute')
+            ->withConsecutive(
+                ['color', 'Blue'],
+                ['material', ['Cotton', 'Linen']]
+            );
+        $product->expects($this->once())
+            ->method('getCustomAttributes')
+            ->willReturn([
+                $this->createConfiguredMock(AttributeValue::class, [
+                    'getAttributeCode' => 'color',
+                    'getValue' => 'Blue',
+                ]),
+                $this->createConfiguredMock(AttributeValue::class, [
+                    'getAttributeCode' => 'material',
+                    'getValue' => ['Cotton', 'Linen'],
+                ]),
+            ]);
+        $product->expects($this->once())
+            ->method('getExtensionAttributes')
+            ->willReturn(null);
+
+        $this->objectManager->expects($this->once())
+            ->method('create')
+            ->with(Product::class)
+            ->willReturn($exportProduct);
+        $exportProduct->expects($this->once())
+            ->method('setData')
+            ->willReturnSelf();
+        $exportProduct->expects($this->exactly(2))
+            ->method('setCustomAttribute')
+            ->withConsecutive(
+                ['color', 'Blue'],
+                ['material', ['Cotton', 'Linen']]
+            )
+            ->willReturnSelf();
+        $exportProduct->expects($this->once())
+            ->method('setAttributeSetName')
+            ->with('Fabric')
+            ->willReturnSelf();
+
+        $result = $this->repository->get('SKU-1');
+
+        $this->assertSame($exportProduct, $result);
+    }
+
+    public function testGetFallsBackToRawOptionValueWhenNoLabelExists(): void
+    {
+        $product = $this->createMock(\Magento\Catalog\Model\Product::class);
+        $exportProduct = $this->createMock(Product::class);
+        $attribute = $this->createConfiguredMock(ProductAttributeInterface::class, [
+            'getAttributeCode' => 'color',
+            'getFrontendInput' => 'select',
+            'getOptions' => [$this->createMock(ProductCustomOptionInterface::class)],
+        ]);
+        $attributeSet = $this->createConfiguredMock(AttributeSetInterface::class, [
+            'getAttributeSetName' => 'Default',
+        ]);
+
+        $this->catalogProductRepository->method('get')->willReturn($product);
+        $this->scopeConfig->expects($this->once())
+            ->method('isSetFlag')
+            ->with('orderflow_product_export/settings/use_attribute_option_labels')
+            ->willReturn(true);
+        $product->method('getAttributeSetId')->willReturn(3);
+        $this->productAttributeManagement->method('getAttributes')->willReturn([$attribute]);
+        $this->attributeSetRepository->method('get')->willReturn($attributeSet);
+        $this->attributeRepository->method('get')->willReturn($this->createAttributeWithOptions([]));
+        $product->method('getData')
+            ->willReturnCallback(function (...$args) {
+                $key = $args[0] ?? null;
+                if ($key === 'color') {
+                    return '999';
+                }
+                if ($key === null) {
+                    return ['sku' => 'SKU-2', 'attribute_set_id' => 3];
+                }
+
+                return null;
+            });
+        $product->expects($this->once())
+            ->method('setCustomAttribute')
+            ->with('color', '999');
+        $product->method('getCustomAttributes')->willReturn([]);
+        $product->method('getExtensionAttributes')->willReturn(null);
+
+        $this->objectManager->method('create')->with(Product::class)->willReturn($exportProduct);
+        $exportProduct->method('setData')->willReturnSelf();
+        $exportProduct->expects($this->never())->method('setCustomAttribute');
+        $exportProduct->method('setExtensionAttributes')->willReturnSelf();
+        $exportProduct->method('setAttributeSetName')->willReturnSelf();
+
+        $this->assertSame($exportProduct, $this->repository->get('SKU-2'));
+    }
+
+    public function testGetSkipsAttributeValueMappingWhenConfigDisabled(): void
+    {
+        $product = $this->createMock(\Magento\Catalog\Model\Product::class);
+        $exportProduct = $this->createMock(Product::class);
+        $attributeSet = $this->createConfiguredMock(AttributeSetInterface::class, [
+            'getAttributeSetName' => 'Default',
+        ]);
+
+        $this->catalogProductRepository->expects($this->once())
+            ->method('get')
+            ->with('SKU-3', false, null)
+            ->willReturn($product);
+        $this->scopeConfig->expects($this->once())
+            ->method('isSetFlag')
+            ->with('orderflow_product_export/settings/use_attribute_option_labels')
+            ->willReturn(false);
+        $product->method('getAttributeSetId')->willReturn(9);
+        $this->productAttributeManagement->expects($this->never())->method('getAttributes');
+        $this->attributeRepository->expects($this->never())->method('get');
+        $product->expects($this->never())->method('setCustomAttribute');
+        $this->attributeSetRepository->expects($this->once())
+            ->method('get')
+            ->with(9)
+            ->willReturn($attributeSet);
+        $product->method('getData')->willReturn(['sku' => 'SKU-3', 'attribute_set_id' => 9]);
+        $product->method('getCustomAttributes')->willReturn([]);
+        $product->method('getExtensionAttributes')->willReturn(null);
+
+        $this->objectManager->expects($this->once())
+            ->method('create')
+            ->with(Product::class)
+            ->willReturn($exportProduct);
+        $exportProduct->expects($this->once())->method('setData')->willReturnSelf();
+        $exportProduct->expects($this->never())->method('setCustomAttribute');
+        $exportProduct->expects($this->once())->method('setAttributeSetName')->with('Default')->willReturnSelf();
+
+        $this->assertSame($exportProduct, $this->repository->get('SKU-3'));
+    }
+
+    public function testGetCopiesSequentialCustomAttributesToExportProduct(): void
+    {
+        $product = $this->createMock(\Magento\Catalog\Model\Product::class);
+        $exportProduct = $this->createMock(Product::class);
+        $attributeSet = $this->createConfiguredMock(AttributeSetInterface::class, [
+            'getAttributeSetName' => 'Default',
+        ]);
+
+        $this->catalogProductRepository->expects($this->once())
+            ->method('get')
+            ->with('SKU-4', false, null)
+            ->willReturn($product);
+        $this->scopeConfig->expects($this->once())
+            ->method('isSetFlag')
+            ->with('orderflow_product_export/settings/use_attribute_option_labels')
+            ->willReturn(false);
+        $product->method('getAttributeSetId')->willReturn(11);
+        $this->productAttributeManagement->expects($this->never())->method('getAttributes');
+        $this->attributeSetRepository->expects($this->once())->method('get')->with(11)->willReturn($attributeSet);
+        $product->method('getData')->willReturn(['sku' => 'SKU-4', 'attribute_set_id' => 11]);
+        $product->method('getCustomAttributes')->willReturn([
+            $this->createConfiguredMock(AttributeValue::class, [
+                'getAttributeCode' => 'brand',
+                'getValue' => 'Sirdar',
+            ]),
+            $this->createConfiguredMock(AttributeValue::class, [
+                'getAttributeCode' => 'condition',
+                'getValue' => 'New',
+            ]),
+        ]);
+        $product->method('getExtensionAttributes')->willReturn(null);
+
+        $this->objectManager->expects($this->once())
+            ->method('create')
+            ->with(Product::class)
+            ->willReturn($exportProduct);
+        $exportProduct->expects($this->once())->method('setData')->willReturnSelf();
+        $exportProduct->expects($this->exactly(2))
+            ->method('setCustomAttribute')
+            ->withConsecutive(
+                ['brand', 'Sirdar'],
+                ['condition', 'New']
+            )
+            ->willReturnSelf();
+        $exportProduct->expects($this->once())->method('setAttributeSetName')->with('Default')->willReturnSelf();
+
+        $this->assertSame($exportProduct, $this->repository->get('SKU-4'));
+    }
+
+    private function createOption(string $value, string $label): AttributeOptionInterface
+    {
+        return $this->createConfiguredMock(AttributeOptionInterface::class, [
+            'getValue' => $value,
+            'getLabel' => $label,
+        ]);
+    }
+
+    private function createAttributeWithOptions(array $options): \Magento\Catalog\Api\Data\ProductAttributeInterface
+    {
+        return $this->createConfiguredMock(ProductAttributeInterface::class, [
+            'getOptions' => $options,
+        ]);
+    }
+}

--- a/Test/Unit/Model/Service/Export/Type/OrderExportExporterTypeTest.php
+++ b/Test/Unit/Model/Service/Export/Type/OrderExportExporterTypeTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Service\Export\Type;
 
+use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderRepository;
 use RealtimeDespatch\OrderFlow\Model\Factory\OrderFlow\Service\OrderServiceFactory;
@@ -13,12 +14,14 @@ use RealtimeDespatch\OrderFlow\Model\Service\Export\Type\OrderExportExporterType
 class OrderExportExporterTypeTest extends AbstractExporterTypeTest
 {
     protected Order $mockOrderRepository;
+    protected DateTime $mockDate;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->mockOrderRepository = $this->createMock(Order::class);
+        $this->mockDate = $this->createMock(DateTime::class);
 
         $this->mockOrderRepository
             ->method('loadByIncrementId')
@@ -29,7 +32,8 @@ class OrderExportExporterTypeTest extends AbstractExporterTypeTest
             $this->mockScopeConfig,
             $this->mockLogger,
             $this->mockObjectManager,
-            $this->mockOrderRepository
+            $this->mockOrderRepository,
+            $this->mockDate
         );
     }
 

--- a/Test/Unit/Model/Service/Export/Type/ProductExportExporterTypeTest.php
+++ b/Test/Unit/Model/Service/Export/Type/ProductExportExporterTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Service\Export\Type;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\OrderRepository;
 use RealtimeDespatch\OrderFlow\Model\Factory\OrderFlow\Service\OrderServiceFactory;
@@ -17,6 +18,7 @@ class ProductExportExporterTypeTest extends AbstractExporterTypeTest
 {
     protected ProductRepositoryInterface $mockProductRepository;
     protected ProductHelper $mockProductHelper;
+    protected DateTime $mockDate;
 
     protected function setUp(): void
     {
@@ -24,13 +26,15 @@ class ProductExportExporterTypeTest extends AbstractExporterTypeTest
 
         $this->mockProductRepository = $this->createMock(ProductRepositoryInterface::class);
         $this->mockProductHelper = $this->createMock(ProductHelper::class);
+        $this->mockDate = $this->createMock(DateTime::class);
 
         $this->exporterType = new ProductExportExporterType(
             $this->mockScopeConfig,
             $this->mockLogger,
             $this->mockObjectManager,
             $this->mockProductRepository,
-            $this->mockProductHelper
+            $this->mockProductHelper,
+            $this->mockDate
         );
     }
 

--- a/Test/Unit/Model/Service/Import/Type/InventoryUpdateImporterTypeTest.php
+++ b/Test/Unit/Model/Service/Import/Type/InventoryUpdateImporterTypeTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Service\Import\Type;
 
+use RealtimeDespatch\OrderFlow\Model\Indexer\ProductReindexer;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\ObjectManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -16,17 +17,20 @@ class InventoryUpdateImporterTypeTest extends AbstractImporterTypeTest
     protected StockHelper\MsiStockHelper $mockMsiStockHelper;
     protected StockHelper\LegacyStockHelper $mockLegacyStockHelper;
     protected StockHelperFactory $mockStockHelperFactory;
+    protected ProductReindexer $mockProductReindexer;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->mockStockHelperFactory = $this->createMock(StockHelperFactory::class);
+        $this->mockProductReindexer = $this->createMock(ProductReindexer::class);
 
         $this->type = new InventoryUpdateImporterType(
             $this->mockScopeConfig,
             $this->mockLogger,
             $this->mockObjectManager,
+            $this->mockProductReindexer,
             $this->mockStockHelperFactory
         );
     }

--- a/Test/Unit/Plugin/Webapi/Soap/ProductExportTest.php
+++ b/Test/Unit/Plugin/Webapi/Soap/ProductExportTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Plugin\Webapi\Soap;
 
 use Magento\Framework\ObjectManagerInterface;
+use Magento\Webapi\Controller\Soap\Request\Handler as SoapRequestHandler;
 use RealtimeDespatch\OrderFlow\Api\RequestBuilderInterface;
+use RealtimeDespatch\OrderFlow\Helper\Export\Product as ProductHelper;
 use RealtimeDespatch\OrderFlow\Model\Service\Request\RequestProcessor;
 use RealtimeDespatch\OrderFlow\Plugin\Webapi\Soap\InventoryImport;
 use RealtimeDespatch\OrderFlow\Plugin\Webapi\Soap\ProductExport;
-use RealtimeDespatch\OrderFlow\Helper\Export\Product as ProductHelper;
-use Magento\Webapi\Controller\Soap\Request\Handler as SoapRequestHandler;
 
 class ProductExportTest extends \PHPUnit\Framework\TestCase
 {
@@ -21,7 +21,7 @@ class ProductExportTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->mockObjectManager = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
+        $this->mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $this->mockProductHelper = $this->createMock(ProductHelper::class);
         $this->mockRequestBuilder = $this->getMockBuilder(RequestBuilderInterface::class)
             ->disableOriginalConstructor()
@@ -39,9 +39,8 @@ class ProductExportTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider testAroundCallDataProvider
-     * @return void
      */
-    public function testAroundCall(bool $productExportEnabled): void
+    public function testAroundCall(string $operation, bool $productExportEnabled): void
     {
         $mockRequestProcessor = $this->createMock(RequestProcessor::class);
 
@@ -64,7 +63,7 @@ class ProductExportTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('setRequestBody');
 
-        $response = ['result' => 'success',];
+        $response = ['result' => 'success'];
 
         $this->mockRequestBuilder
             ->expects($this->once())
@@ -83,21 +82,21 @@ class ProductExportTest extends \PHPUnit\Framework\TestCase
             ->method('saveRequest')
             ->willReturn($mockRequest);
 
+        $this->mockProductHelper
+            ->expects($this->once())
+            ->method('isProductExportEnabledForProductWebsites')
+            ->with('SKU-1234')
+            ->willReturn($productExportEnabled);
+
         if (!$productExportEnabled) {
             $this->expectException(\Magento\Framework\Webapi\Exception::class);
             $this->expectExceptionMessage("Product 'SKU-1234' is not in any product export enabled websites");
-        } else {
-            $this->mockProductHelper
-                ->expects($this->once())
-                ->method('isProductExportEnabledForProductWebsites')
-                ->with('SKU-1234')
-                ->willReturn(true);
         }
 
         $this->plugin->around__call(
             $this->mockSoapRequestHandler,
             fn() => $response,
-            'catalogProductRepositoryV1Get',
+            $operation,
             [
                 (object) [
                     'sku' => 'SKU-1234',
@@ -113,9 +112,14 @@ class ProductExportTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->with('ProductExportRequestProcessor');
 
+        $this->mockProductHelper
+            ->expects($this->never())
+            ->method('isProductExportEnabledForProductWebsites');
+
         $this->plugin->around__call(
             $this->mockSoapRequestHandler,
-            function() { },
+            function () {
+            },
             InventoryImport::class,
             [
                 (object) [
@@ -128,8 +132,10 @@ class ProductExportTest extends \PHPUnit\Framework\TestCase
     public function testAroundCallDataProvider(): array
     {
         return [
-            [true],
-            [false],
+            ['catalogProductRepositoryV1Get', true],
+            ['catalogProductRepositoryV1Get', false],
+            ['realtimeDespatchOrderFlowProductRepositoryV1Get', true],
+            ['realtimeDespatchOrderFlowProductRepositoryV1Get', false],
         ];
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -99,6 +99,11 @@
                     <label>Store ID</label>
                     <source_model>Magento\Config\Model\Config\Source\Store</source_model>
                 </field>
+                <field id="use_attribute_option_labels" translate="label comment" type="select" sortOrder="5" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Use Attribute Option Labels</label>
+                    <comment>When enabled, product export responses return attribute option labels instead of stored option IDs for select and multiselect product attributes.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
         <section id="orderflow_inventory_import" translate="label" type="text" sortOrder="5000" showInDefault="1" showInWebsite="0" showInStore="0">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -30,6 +30,7 @@
                 <is_enabled>1</is_enabled>
                 <batch_size>100</batch_size>
                 <cron_expression>* * * * *</cron_expression>
+                <use_attribute_option_labels>0</use_attribute_option_labels>
             </settings>
         </orderflow_product_export>
         <orderflow_log_cleaning>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,6 +13,8 @@
     <preference for="RealtimeDespatch\OrderFlow\Api\InventoryRequestManagementInterface" type="RealtimeDespatch\OrderFlow\Model\Service\InventoryRequestService" />
     <preference for="RealtimeDespatch\OrderFlow\Api\OrderRequestManagementInterface" type="RealtimeDespatch\OrderFlow\Model\Service\OrderRequestService" />
     <preference for="RealtimeDespatch\OrderFlow\Api\ProductRequestManagementInterface" type="RealtimeDespatch\OrderFlow\Model\Service\ProductRequestService" />
+    <preference for="RealtimeDespatch\OrderFlow\Api\ProductRepositoryInterface" type="RealtimeDespatch\OrderFlow\Model\ProductRepository" />
+    <preference for="RealtimeDespatch\OrderFlow\Api\Data\ProductInterface" type="RealtimeDespatch\OrderFlow\Model\Data\Product" />
     <preference for="RealtimeDespatch\OrderFlow\Api\RequestBuilderInterface" type="RealtimeDespatch\OrderFlow\Model\Builder\RequestBuilder" />
     <preference for="RealtimeDespatch\OrderFlow\Api\Data\SequenceItemInterface" type="RealtimeDespatch\OrderFlow\Model\SequenceItem" />
     <preference for="RealtimeDespatch\OrderFlow\Api\Data\QuantityItemInterface" type="RealtimeDespatch\OrderFlow\Model\QuantityItem" />

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <route url="/V1/orderflow/product/:sku" method="GET">
+        <service class="RealtimeDespatch\OrderFlow\Api\ProductRepositoryInterface" method="get"/>
+        <resources>
+            <resource ref="Magento_Catalog::products" />
+        </resources>
+    </route>
     <!-- Products -->
     <route url="/V1/orderflow/export/product" method="POST">
         <service class="RealtimeDespatch\OrderFlow\Api\ProductRequestManagementInterface" method="export"/>


### PR DESCRIPTION
## Title

Add OrderFlow product export endpoint

## Description

## Summary

This adds an OrderFlow-owned product endpoint at `/V1/orderflow/product/:sku` and, most importantly, allows product export responses to return attribute option labels instead of stored option IDs.

## Included

- new OrderFlow product endpoint and SOAP operation
- optional `Use Attribute Option Labels` config
- `attribute_set_name` added alongside the existing numeric `attribute_set_id`
- support for both:
  - `realtimeDespatchOrderFlowProductRepositoryV1Get`
  - `catalogProductRepositoryV1Get`
- unit coverage for the new endpoint behavior and custom attribute handling

## Behaviour

When `Use Attribute Option Labels` is enabled:
- `select` and `multiselect` product attributes are returned as labels rather than stored IDs
- if a label cannot be resolved, the raw stored value is returned

When disabled:
- attribute values are returned as stored