### PR TITLE
Add Disabled as product export status 

### DIFF
--- a/Helper/Export/Order.php
+++ b/Helper/Export/Order.php
@@ -11,6 +11,7 @@ class Order extends \Magento\Framework\App\Helper\AbstractHelper
 {
     const STATUS_PENDING = 'Pending';
     const STATUS_QUEUED = 'Queued';
+    const STATUS_EXPORTED = 'Exported';
 
     /**
      * @var \Mage\Sales\Model\OrderFactory
@@ -132,7 +133,7 @@ class Order extends \Magento\Framework\App\Helper\AbstractHelper
             ->addFieldToFilter('is_virtual', ['eq' => 0])
             ->addFieldToFilter('orderflow_export_date', ['null' => true])
             ->addFieldToFilter('orderflow_export_status', [
-                ['nin' => [self::STATUS_QUEUED, 'Exported']],
+                ['nin' => [self::STATUS_QUEUED, self::STATUS_EXPORTED]],
                 ['null' => true],
             ])
             ->setPage(1, $this->getBatchSize($website->getId()));

--- a/Helper/Export/Product.php
+++ b/Helper/Export/Product.php
@@ -187,7 +187,7 @@ class Product extends \Magento\Framework\App\Helper\AbstractHelper
             ->addAttributeToFilter('orderflow_export_date', ['null' => true])
             ->addAttributeToFilter([
                 ['attribute' => 'orderflow_export_status', 'null' => true],
-                ['attribute' => 'orderflow_export_status', array('neq' => ['Queued'])],
+                ['attribute' => 'orderflow_export_status', 'nin' => ['Queued', 'Disabled']],
             ],
             '',
             'left')

--- a/Model/Product/Attribute/Source/ExportStatus.php
+++ b/Model/Product/Attribute/Source/ExportStatus.php
@@ -18,7 +18,8 @@ class ExportStatus extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSo
             ['value' => 'Pending', 'label' => __('Pending')],
             ['value' => 'Queued', 'label' => __('Queued')],
             ['value' => 'Exported', 'label' => __('Exported')],
-            ['value' => 'Failed', 'label' => __('Failed')]
+            ['value' => 'Failed', 'label' => __('Failed')],
+            ['value' => 'Disabled', 'label' => __('Disabled')]
         ];
     }
 }

--- a/Model/Product/ExportStatus/Options.php
+++ b/Model/Product/ExportStatus/Options.php
@@ -31,6 +31,9 @@ class Options implements \Magento\Framework\Data\OptionSourceInterface
             array(
                 'value' => 'Failed', 'label' => 'Failed',
             ),
+            array(
+                'value' => 'Disabled', 'label' => 'Disabled',
+            ),
         );
     }
 }

--- a/Model/Source/Export/Status.php
+++ b/Model/Source/Export/Status.php
@@ -18,7 +18,8 @@ class Status implements \Magento\Framework\Option\ArrayInterface
             ['value' => 'Pending', 'label' => __('Pending')],
             ['value' => 'Queued', 'label' => __('Queued')],
             ['value' => 'Exported', 'label' => __('Exported')],
-            ['value' => 'Failed', 'label' => __('Failed')]
+            ['value' => 'Failed', 'label' => __('Failed')],
+            ['value' => 'Disabled', 'label' => __('Disabled')]
         ];
     }
 
@@ -27,6 +28,12 @@ class Status implements \Magento\Framework\Option\ArrayInterface
      */
     public function toArray()
     {
-        return ['Pending' => __('Pending'), 'Queued' => __('Queued'), 'Exported' => __('Exported'), 'Failed' => __('Failed')];
+        return [
+            'Pending' => __('Pending'),
+            'Queued' => __('Queued'),
+            'Exported' => __('Exported'),
+            'Failed' => __('Failed'),
+            'Disabled' => __('Disabled')
+        ];
     }
 }

--- a/Plugin/Catalog/ProductSave.php
+++ b/Plugin/Catalog/ProductSave.php
@@ -9,6 +9,7 @@ namespace RealtimeDespatch\OrderFlow\Plugin\Catalog;
 class ProductSave
 {
     const EXPORT_STATUS_PENDING = 'Pending';
+    const EXPORT_STATUS_DISABLED = 'Disabled';
 
     /**
      * Resets the Export Status if a product has been updated.
@@ -24,6 +25,10 @@ class ProductSave
 
         // If a separate process has amended the export status ignore.
         if ($product->dataHasChangedFor('orderflow_export_status')) {
+            return array($product);
+        }
+
+        if ($product->getData('orderflow_export_status') === self::EXPORT_STATUS_DISABLED) {
             return array($product);
         }
 

--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -117,7 +117,8 @@ class InstallData implements InstallDataInterface
                         'Pending',
                         'Queued',
                         'Exported',
-                        'Failed'
+                        'Failed',
+                        'Disabled'
                     ]
                 ]
             ]

--- a/Test/Unit/Helper/Export/ProductTest.php
+++ b/Test/Unit/Helper/Export/ProductTest.php
@@ -106,7 +106,16 @@ class ProductTest extends TestCase
 
         $mockProductCollection = $this->createMock(ProductCollection::class);
         $mockProductCollection
+            ->expects($this->exactly(3))
             ->method('addAttributeToFilter')
+            ->withConsecutive(
+                ['type_id', ['eq' => 'simple']],
+                ['orderflow_export_date', ['null' => true]],
+                [[
+                    ['attribute' => 'orderflow_export_status', 'null' => true],
+                    ['attribute' => 'orderflow_export_status', 'nin' => ['Queued', 'Disabled']],
+                ], '', 'left']
+            )
             ->willReturnSelf();
 
         $mockProductCollection

--- a/Test/Unit/Model/Indexer/ProductReindexerTest.php
+++ b/Test/Unit/Model/Indexer/ProductReindexerTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Indexer;
+
+use Magento\Catalog\Model\ResourceModel\Product as ProductResourceModel;
+use Magento\Framework\Indexer\IndexerInterface;
+use Magento\Framework\Indexer\IndexerRegistry;
+use Magento\Framework\Module\Manager;
+use PHPUnit\Framework\TestCase;
+use RealtimeDespatch\OrderFlow\Model\Indexer\ProductReindexer;
+
+class ProductReindexerTest extends TestCase
+{
+    private Manager $moduleManager;
+    private IndexerRegistry $indexerRegistry;
+    private ProductResourceModel $productResource;
+    private ProductReindexer $reindexer;
+
+    protected function setUp(): void
+    {
+        $this->moduleManager = $this->createMock(Manager::class);
+        $this->indexerRegistry = $this->createMock(IndexerRegistry::class);
+        $this->productResource = $this->createMock(ProductResourceModel::class);
+
+        $this->reindexer = new ProductReindexer(
+            $this->moduleManager,
+            $this->indexerRegistry,
+            $this->productResource
+        );
+    }
+
+    public function testReindexSkusReturnsEarlyForEmptySkuList(): void
+    {
+        $this->moduleManager->expects($this->never())->method('isEnabled');
+        $this->productResource->expects($this->never())->method('getProductsIdsBySkus');
+
+        $this->reindexer->reindexSkus([]);
+    }
+
+    public function testReindexSkusReturnsEarlyWhenMsiIsDisabled(): void
+    {
+        $this->moduleManager
+            ->expects($this->once())
+            ->method('isEnabled')
+            ->with('Magento_InventoryApi')
+            ->willReturn(false);
+
+        $this->productResource->expects($this->never())->method('getProductsIdsBySkus');
+
+        $this->reindexer->reindexSkus(['ABC123']);
+    }
+
+    public function testReindexSkusReturnsEarlyWhenNoProductsAreResolved(): void
+    {
+        $this->moduleManager
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $this->productResource
+            ->expects($this->once())
+            ->method('getProductsIdsBySkus')
+            ->with(['ABC123'])
+            ->willReturn([]);
+
+        $this->indexerRegistry->expects($this->never())->method('get');
+
+        $this->reindexer->reindexSkus(['ABC123']);
+    }
+
+    public function testReindexSkusReindexesResolvedIdsAcrossAllIndexers(): void
+    {
+        $catalogInventoryIndexer = $this->createMock(IndexerInterface::class);
+        $catalogPriceIndexer = $this->createMock(IndexerInterface::class);
+        $catalogSearchIndexer = $this->createMock(IndexerInterface::class);
+
+        $this->moduleManager
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $this->productResource
+            ->expects($this->once())
+            ->method('getProductsIdsBySkus')
+            ->with(['ABC123', 'DEF456'])
+            ->willReturn([
+                'ABC123' => '10',
+                'DEF456' => 20,
+            ]);
+
+        $this->indexerRegistry
+            ->expects($this->exactly(3))
+            ->method('get')
+            ->willReturnMap([
+                ['cataloginventory_stock', $catalogInventoryIndexer],
+                ['catalog_product_price', $catalogPriceIndexer],
+                ['catalogsearch_fulltext', $catalogSearchIndexer],
+            ]);
+
+        $catalogInventoryIndexer
+            ->expects($this->once())
+            ->method('reindexList')
+            ->with([10, 20]);
+
+        $catalogPriceIndexer
+            ->expects($this->once())
+            ->method('reindexList')
+            ->with([10, 20]);
+
+        $catalogSearchIndexer
+            ->expects($this->once())
+            ->method('reindexList')
+            ->with([10, 20]);
+
+        $this->reindexer->reindexSkus(['ABC123', 'ABC123', 'DEF456']);
+    }
+}

--- a/Test/Unit/Model/Product/Attribute/Source/ExportStatusTest.php
+++ b/Test/Unit/Model/Product/Attribute/Source/ExportStatusTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Product\Attribute\Source;
+
+use RealtimeDespatch\OrderFlow\Model\Product\Attribute\Source\ExportStatus;
+
+class ExportStatusTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetAllOptionsIncludesDisabled(): void
+    {
+        $source = new ExportStatus();
+
+        $result = $source->getAllOptions();
+
+        $this->assertSame(
+            ['Pending', 'Queued', 'Exported', 'Failed', 'Disabled'],
+            array_map(static fn(array $option) => $option['value'], $result)
+        );
+    }
+}

--- a/Test/Unit/Model/Product/ExportStatus/OptionsTest.php
+++ b/Test/Unit/Model/Product/ExportStatus/OptionsTest.php
@@ -19,7 +19,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $result = $this->options->toOptionArray();
         $this->assertIsArray($result);
         $this->assertNotEmpty($result);
-        $expected = array_map(fn($x) => ['value' => $x, 'label' => $x], ['Pending', 'Queued', 'Exported', 'Failed']);
+        $expected = array_map(fn($x) => ['value' => $x, 'label' => $x], ['Pending', 'Queued', 'Exported', 'Failed', 'Disabled']);
         $this->assertEquals($expected, $result);
     }
 }

--- a/Test/Unit/Model/Service/Export/Type/OrderExportExporterTypeTest.php
+++ b/Test/Unit/Model/Service/Export/Type/OrderExportExporterTypeTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Service\Export\Type;
 
+use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderRepository;
 use RealtimeDespatch\OrderFlow\Model\Factory\OrderFlow\Service\OrderServiceFactory;
@@ -13,12 +14,14 @@ use RealtimeDespatch\OrderFlow\Model\Service\Export\Type\OrderExportExporterType
 class OrderExportExporterTypeTest extends AbstractExporterTypeTest
 {
     protected Order $mockOrderRepository;
+    protected DateTime $mockDate;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->mockOrderRepository = $this->createMock(Order::class);
+        $this->mockDate = $this->createMock(DateTime::class);
 
         $this->mockOrderRepository
             ->method('loadByIncrementId')
@@ -29,7 +32,8 @@ class OrderExportExporterTypeTest extends AbstractExporterTypeTest
             $this->mockScopeConfig,
             $this->mockLogger,
             $this->mockObjectManager,
-            $this->mockOrderRepository
+            $this->mockOrderRepository,
+            $this->mockDate
         );
     }
 

--- a/Test/Unit/Model/Service/Export/Type/ProductExportExporterTypeTest.php
+++ b/Test/Unit/Model/Service/Export/Type/ProductExportExporterTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Service\Export\Type;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\OrderRepository;
 use RealtimeDespatch\OrderFlow\Model\Factory\OrderFlow\Service\OrderServiceFactory;
@@ -17,6 +18,7 @@ class ProductExportExporterTypeTest extends AbstractExporterTypeTest
 {
     protected ProductRepositoryInterface $mockProductRepository;
     protected ProductHelper $mockProductHelper;
+    protected DateTime $mockDate;
 
     protected function setUp(): void
     {
@@ -24,13 +26,15 @@ class ProductExportExporterTypeTest extends AbstractExporterTypeTest
 
         $this->mockProductRepository = $this->createMock(ProductRepositoryInterface::class);
         $this->mockProductHelper = $this->createMock(ProductHelper::class);
+        $this->mockDate = $this->createMock(DateTime::class);
 
         $this->exporterType = new ProductExportExporterType(
             $this->mockScopeConfig,
             $this->mockLogger,
             $this->mockObjectManager,
             $this->mockProductRepository,
-            $this->mockProductHelper
+            $this->mockProductHelper,
+            $this->mockDate
         );
     }
 

--- a/Test/Unit/Model/Service/Import/Type/InventoryUpdateImporterTypeTest.php
+++ b/Test/Unit/Model/Service/Import/Type/InventoryUpdateImporterTypeTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Service\Import\Type;
 
+use RealtimeDespatch\OrderFlow\Model\Indexer\ProductReindexer;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\ObjectManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -16,17 +17,20 @@ class InventoryUpdateImporterTypeTest extends AbstractImporterTypeTest
     protected StockHelper\MsiStockHelper $mockMsiStockHelper;
     protected StockHelper\LegacyStockHelper $mockLegacyStockHelper;
     protected StockHelperFactory $mockStockHelperFactory;
+    protected ProductReindexer $mockProductReindexer;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->mockStockHelperFactory = $this->createMock(StockHelperFactory::class);
+        $this->mockProductReindexer = $this->createMock(ProductReindexer::class);
 
         $this->type = new InventoryUpdateImporterType(
             $this->mockScopeConfig,
             $this->mockLogger,
             $this->mockObjectManager,
+            $this->mockProductReindexer,
             $this->mockStockHelperFactory
         );
     }

--- a/Test/Unit/Model/Source/Export/StatusTest.php
+++ b/Test/Unit/Model/Source/Export/StatusTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Source\Export;
+
+use RealtimeDespatch\OrderFlow\Model\Source\Export\Status;
+
+class StatusTest extends \PHPUnit\Framework\TestCase
+{
+    public function testToOptionArrayIncludesDisabled(): void
+    {
+        $source = new Status();
+
+        $result = $source->toOptionArray();
+
+        $this->assertSame(
+            ['Pending', 'Queued', 'Exported', 'Failed', 'Disabled'],
+            array_map(static fn(array $option) => $option['value'], $result)
+        );
+    }
+
+    public function testToArrayIncludesDisabled(): void
+    {
+        $source = new Status();
+
+        $result = $source->toArray();
+
+        $this->assertArrayHasKey('Disabled', $result);
+    }
+}

--- a/Test/Unit/Plugin/Catalog/ProductSaveTest.php
+++ b/Test/Unit/Plugin/Catalog/ProductSaveTest.php
@@ -20,7 +20,7 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
         $this->mockProduct = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
             ->disableOriginalConstructor()
             ->addMethods(['setOrderflowExportStatus'])
-            ->onlyMethods(['isDataChanged', 'dataHasChangedFor'])
+            ->onlyMethods(['isDataChanged', 'dataHasChangedFor', 'getData'])
             ->getMock();
 
         $this->mockProductResource = $this->createMock(\Magento\Catalog\Model\ResourceModel\Product::class);
@@ -50,8 +50,47 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
 
         $this->mockProduct
             ->expects($this->once())
+            ->method('dataHasChangedFor')
+            ->with('orderflow_export_status')
+            ->willReturn(false);
+
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('getData')
+            ->with('orderflow_export_status')
+            ->willReturn('Queued');
+
+        $this->mockProduct
+            ->expects($this->once())
             ->method('setOrderflowExportStatus')
             ->with('Pending');
+
+        $result = $this->plugin->beforeSave($this->mockProductResource, $this->mockProduct);
+        $this->assertEquals($this->mockProduct, $result[0]);
+    }
+
+    public function testBeforeSaveDisabledStatusPreserved(): void
+    {
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('isDataChanged')
+            ->willReturn(true);
+
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('dataHasChangedFor')
+            ->with('orderflow_export_status')
+            ->willReturn(false);
+
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('getData')
+            ->with('orderflow_export_status')
+            ->willReturn('Disabled');
+
+        $this->mockProduct
+            ->expects($this->never())
+            ->method('setOrderflowExportStatus');
 
         $result = $this->plugin->beforeSave($this->mockProductResource, $this->mockProduct);
         $this->assertEquals($this->mockProduct, $result[0]);


### PR DESCRIPTION
## Summary

This feature makes `Disabled` a product export status.

## Included

- adds `Disabled` to the product export status option providers
- updates normal product save handling so an existing `Disabled` status is preserved
- excludes `Disabled` products from the createable product export candidate set
- updates install-time attribute setup for completeness on fresh installs
- adds focused unit coverage for the save plugin, createable-product filter, and status option models

## Behaviour

After this change:

- `Disabled` is available as a native `orderflow_export_status` value
- products already marked `Disabled` are not reset to `Pending` by the existing product save mechanism
- products marked `Disabled` are not selected as createable export candidates