### PR TITLE
Expand product change detection for update triggering

### DIFF
--- a/Helper/Export/Order.php
+++ b/Helper/Export/Order.php
@@ -11,6 +11,7 @@ class Order extends \Magento\Framework\App\Helper\AbstractHelper
 {
     const STATUS_PENDING = 'Pending';
     const STATUS_QUEUED = 'Queued';
+    const STATUS_EXPORTED = 'Exported';
 
     /**
      * @var \Mage\Sales\Model\OrderFactory
@@ -132,7 +133,7 @@ class Order extends \Magento\Framework\App\Helper\AbstractHelper
             ->addFieldToFilter('is_virtual', ['eq' => 0])
             ->addFieldToFilter('orderflow_export_date', ['null' => true])
             ->addFieldToFilter('orderflow_export_status', [
-                ['nin' => [self::STATUS_QUEUED, 'Exported']],
+                ['nin' => [self::STATUS_QUEUED, self::STATUS_EXPORTED]],
                 ['null' => true],
             ])
             ->setPage(1, $this->getBatchSize($website->getId()));

--- a/Helper/Export/Product.php
+++ b/Helper/Export/Product.php
@@ -187,7 +187,7 @@ class Product extends \Magento\Framework\App\Helper\AbstractHelper
             ->addAttributeToFilter('orderflow_export_date', ['null' => true])
             ->addAttributeToFilter([
                 ['attribute' => 'orderflow_export_status', 'null' => true],
-                ['attribute' => 'orderflow_export_status', array('neq' => ['Queued'])],
+                ['attribute' => 'orderflow_export_status', 'nin' => ['Queued', 'Disabled']],
             ],
             '',
             'left')

--- a/Model/Product/Attribute/Source/ExportStatus.php
+++ b/Model/Product/Attribute/Source/ExportStatus.php
@@ -18,7 +18,8 @@ class ExportStatus extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSo
             ['value' => 'Pending', 'label' => __('Pending')],
             ['value' => 'Queued', 'label' => __('Queued')],
             ['value' => 'Exported', 'label' => __('Exported')],
-            ['value' => 'Failed', 'label' => __('Failed')]
+            ['value' => 'Failed', 'label' => __('Failed')],
+            ['value' => 'Disabled', 'label' => __('Disabled')]
         ];
     }
 }

--- a/Model/Product/ExportStatus/Options.php
+++ b/Model/Product/ExportStatus/Options.php
@@ -31,6 +31,9 @@ class Options implements \Magento\Framework\Data\OptionSourceInterface
             array(
                 'value' => 'Failed', 'label' => 'Failed',
             ),
+            array(
+                'value' => 'Disabled', 'label' => 'Disabled',
+            ),
         );
     }
 }

--- a/Model/Product/ExportStatus/ProductExportStatusResolver.php
+++ b/Model/Product/ExportStatus/ProductExportStatusResolver.php
@@ -1,0 +1,148 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Model\Product\ExportStatus;
+
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+
+class ProductExportStatusResolver
+{
+    public const STATUS_PENDING = 'Pending';
+    public const STATUS_DISABLED = 'Disabled';
+
+    public function __construct(
+        private readonly CollectionFactory $productCollectionFactory
+    ) {}
+
+    public function shouldSetPending($currentStatus, bool $statusChangedExplicitly): bool
+    {
+        if ($statusChangedExplicitly) {
+            return false;
+        }
+
+        return $currentStatus !== self::STATUS_DISABLED;
+    }
+
+    /**
+     * @param mixed[] $productIds
+     * @return int[]
+     */
+    public function getProductIdsToSetPending(array $productIds): array
+    {
+        $productIds = $this->normalizeProductIds($productIds);
+        if ($productIds === []) {
+            return [];
+        }
+
+        $collection = $this->productCollectionFactory->create();
+        $collection->addIdFilter($productIds);
+        $collection->addAttributeToSelect('orderflow_export_status');
+
+        return $this->extractProductIdsToSetPending($collection);
+    }
+
+    /**
+     * @param mixed[] $skus
+     * @return int[]
+     */
+    public function getProductIdsBySkusToSetPending(array $skus): array
+    {
+        $skus = $this->normalizeSkus($skus);
+        if ($skus === []) {
+            return [];
+        }
+
+        $collection = $this->productCollectionFactory->create();
+        $collection->addAttributeToSelect('orderflow_export_status');
+        $collection->addAttributeToFilter('sku', ['in' => $skus]);
+
+        return $this->extractProductIdsToSetPending($collection);
+    }
+
+    /**
+     * @param mixed[] $skus
+     * @return string[]
+     */
+    public function getSkusToSetPending(array $skus): array
+    {
+        $skus = $this->normalizeSkus($skus);
+        if ($skus === []) {
+            return [];
+        }
+
+        $collection = $this->productCollectionFactory->create();
+        $collection->addAttributeToSelect('orderflow_export_status');
+        $collection->addAttributeToFilter('sku', ['in' => $skus]);
+
+        $eligibleSkus = array_fill_keys($skus, true);
+
+        foreach ($collection as $product) {
+            if (!$this->shouldSetPending($product->getData('orderflow_export_status'), false)) {
+                $sku = trim((string)$product->getSku());
+                if ($sku !== '') {
+                    unset($eligibleSkus[$sku]);
+                }
+            }
+        }
+
+        return array_values(array_keys($eligibleSkus));
+    }
+
+    /**
+     * @param mixed[] $productIds
+     * @return int[]
+     */
+    private function normalizeProductIds(array $productIds): array
+    {
+        $normalizedProductIds = [];
+
+        foreach ($productIds as $productId) {
+            $productId = (int)$productId;
+            if ($productId > 0) {
+                $normalizedProductIds[$productId] = $productId;
+            }
+        }
+
+        return array_values($normalizedProductIds);
+    }
+
+    /**
+     * @param mixed[] $skus
+     * @return string[]
+     */
+    private function normalizeSkus(array $skus): array
+    {
+        $normalizedSkus = [];
+
+        foreach ($skus as $sku) {
+            $sku = trim((string)$sku);
+            if ($sku !== '') {
+                $normalizedSkus[$sku] = $sku;
+            }
+        }
+
+        return array_values($normalizedSkus);
+    }
+
+    /**
+     * @param iterable<\Magento\Catalog\Api\Data\ProductInterface> $products
+     * @return int[]
+     */
+    private function extractProductIdsToSetPending(iterable $products): array
+    {
+        $eligibleProductIds = [];
+
+        foreach ($products as $product) {
+            if (!$this->shouldSetPending($product->getData('orderflow_export_status'), false)) {
+                continue;
+            }
+
+            $productId = (int)$product->getId();
+            if ($productId > 0) {
+                $eligibleProductIds[] = $productId;
+            }
+        }
+
+        return $eligibleProductIds;
+    }
+}

--- a/Model/Source/Export/Status.php
+++ b/Model/Source/Export/Status.php
@@ -18,7 +18,8 @@ class Status implements \Magento\Framework\Option\ArrayInterface
             ['value' => 'Pending', 'label' => __('Pending')],
             ['value' => 'Queued', 'label' => __('Queued')],
             ['value' => 'Exported', 'label' => __('Exported')],
-            ['value' => 'Failed', 'label' => __('Failed')]
+            ['value' => 'Failed', 'label' => __('Failed')],
+            ['value' => 'Disabled', 'label' => __('Disabled')]
         ];
     }
 
@@ -27,6 +28,12 @@ class Status implements \Magento\Framework\Option\ArrayInterface
      */
     public function toArray()
     {
-        return ['Pending' => __('Pending'), 'Queued' => __('Queued'), 'Exported' => __('Exported'), 'Failed' => __('Failed')];
+        return [
+            'Pending' => __('Pending'),
+            'Queued' => __('Queued'),
+            'Exported' => __('Exported'),
+            'Failed' => __('Failed'),
+            'Disabled' => __('Disabled')
+        ];
     }
 }

--- a/Plugin/Catalog/ProductActionUpdateAttributes.php
+++ b/Plugin/Catalog/ProductActionUpdateAttributes.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Plugin\Catalog;
+
+use Magento\Catalog\Model\Product\Action as ProductAction;
+use Magento\Catalog\Model\ResourceModel\Product\Action as ProductActionResource;
+use Magento\Store\Model\Store;
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
+
+class ProductActionUpdateAttributes
+{
+    public function __construct(
+        private readonly ProductExportStatusResolver $productExportStatusResolver,
+        private readonly ProductActionResource $productActionResource
+    ) {}
+
+    public function aroundUpdateAttributes(
+        ProductAction $subject,
+        callable $proceed,
+        $productIds,
+        $attrData,
+        $storeId
+    ) {
+        $result = $proceed($productIds, $attrData, $storeId);
+
+        if (array_key_exists('orderflow_export_status', $attrData)) {
+            return $result;
+        }
+
+        $eligibleProductIds = $this->productExportStatusResolver->getProductIdsToSetPending((array)$productIds);
+        if ($eligibleProductIds === []) {
+            return $result;
+        }
+
+        $this->productActionResource->updateAttributes(
+            $eligibleProductIds,
+            ['orderflow_export_status' => ProductExportStatusResolver::STATUS_PENDING],
+            Store::DEFAULT_STORE_ID
+        );
+
+        return $result;
+    }
+}

--- a/Plugin/Catalog/ProductSave.php
+++ b/Plugin/Catalog/ProductSave.php
@@ -2,14 +2,17 @@
 
 namespace RealtimeDespatch\OrderFlow\Plugin\Catalog;
 
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
+
 /**
  * Class ProductSave
  * @package RealtimeDespatch\OrderFlow\Plugin\Catalog
  */
 class ProductSave
 {
-    const EXPORT_STATUS_PENDING = 'Pending';
-    const EXPORT_STATUS_DISABLED = 'Disabled';
+    public function __construct(
+        private readonly ProductExportStatusResolver $productExportStatusResolver
+    ) {}
 
     /**
      * Resets the Export Status if a product has been updated.
@@ -23,17 +26,15 @@ class ProductSave
             return array($product);
         }
 
-        // If a separate process has amended the export status ignore.
-        if ($product->dataHasChangedFor('orderflow_export_status')) {
-            return array($product);
-        }
-
-        if ($product->getData('orderflow_export_status') === self::EXPORT_STATUS_DISABLED) {
+        if (!$this->productExportStatusResolver->shouldSetPending(
+            $product->getData('orderflow_export_status'),
+            $product->dataHasChangedFor('orderflow_export_status')
+        )) {
             return array($product);
         }
 
         // Set pending export status.
-        $product->setOrderflowExportStatus(self::EXPORT_STATUS_PENDING);
+        $product->setOrderflowExportStatus(ProductExportStatusResolver::STATUS_PENDING);
 
         return array($product);
     }

--- a/Plugin/Catalog/ProductSave.php
+++ b/Plugin/Catalog/ProductSave.php
@@ -9,6 +9,7 @@ namespace RealtimeDespatch\OrderFlow\Plugin\Catalog;
 class ProductSave
 {
     const EXPORT_STATUS_PENDING = 'Pending';
+    const EXPORT_STATUS_DISABLED = 'Disabled';
 
     /**
      * Resets the Export Status if a product has been updated.
@@ -24,6 +25,10 @@ class ProductSave
 
         // If a separate process has amended the export status ignore.
         if ($product->dataHasChangedFor('orderflow_export_status')) {
+            return array($product);
+        }
+
+        if ($product->getData('orderflow_export_status') === self::EXPORT_STATUS_DISABLED) {
             return array($product);
         }
 

--- a/Plugin/ImportExport/ImportDataPlugin.php
+++ b/Plugin/ImportExport/ImportDataPlugin.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Plugin\ImportExport;
+
+use Magento\CatalogImportExport\Model\Import\Product as ProductImport;
+use Magento\ImportExport\Model\ResourceModel\Import\Data as ImportDataResource;
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
+
+class ImportDataPlugin
+{
+    private const ENTITY_TYPE_CODE = 'catalog_product';
+
+    public function __construct(
+        private readonly ProductExportStatusResolver $productExportStatusResolver
+    ) {}
+
+    public function afterGetNextBunch(ImportDataResource $subject, $result)
+    {
+        return $this->processBunch($subject, $result);
+    }
+
+    public function afterGetNextUniqueBunch(ImportDataResource $subject, $result, $ids = null)
+    {
+        return $this->processBunch($subject, $result, $ids);
+    }
+
+    private function processBunch(ImportDataResource $subject, $result, $ids = null)
+    {
+        if (!is_array($result) || $result === []) {
+            return $result;
+        }
+
+        if ($subject->getEntityTypeCode($ids) !== self::ENTITY_TYPE_CODE) {
+            return $result;
+        }
+
+        $currentSku = null;
+        $candidateSkus = [];
+        $explicitStatusSkus = [];
+
+        foreach ($result as $rowData) {
+            if (!is_array($rowData)) {
+                continue;
+            }
+
+            $rowSku = trim((string)($rowData[ProductImport::COL_SKU] ?? ''));
+            if ($rowSku !== '') {
+                $currentSku = $rowSku;
+            }
+
+            if ($currentSku === null) {
+                continue;
+            }
+
+            $candidateSkus[$currentSku] = $currentSku;
+
+            if (array_key_exists('orderflow_export_status', $rowData)) {
+                $explicitStatusSkus[$currentSku] = $currentSku;
+            }
+        }
+
+        if ($candidateSkus === []) {
+            return $result;
+        }
+
+        $candidateSkus = array_values(array_diff_key($candidateSkus, $explicitStatusSkus));
+        if ($candidateSkus === []) {
+            return $result;
+        }
+
+        $eligibleSkus = array_flip($this->productExportStatusResolver->getSkusToSetPending($candidateSkus));
+        if ($eligibleSkus === []) {
+            return $result;
+        }
+
+        $currentSku = null;
+        foreach ($result as $index => $rowData) {
+            if (!is_array($rowData)) {
+                continue;
+            }
+
+            $rowSku = trim((string)($rowData[ProductImport::COL_SKU] ?? ''));
+            if ($rowSku !== '') {
+                $currentSku = $rowSku;
+            }
+
+            if ($currentSku === null) {
+                continue;
+            }
+
+            if (array_key_exists('orderflow_export_status', $rowData)) {
+                continue;
+            }
+
+            if (!isset($eligibleSkus[$currentSku])) {
+                continue;
+            }
+
+            $rowData['orderflow_export_status'] = ProductExportStatusResolver::STATUS_PENDING;
+            $result[$index] = $rowData;
+        }
+
+        return $result;
+    }
+}

--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -117,7 +117,8 @@ class InstallData implements InstallDataInterface
                         'Pending',
                         'Queued',
                         'Exported',
-                        'Failed'
+                        'Failed',
+                        'Disabled'
                     ]
                 ]
             ]

--- a/Test/Unit/Helper/Export/ProductTest.php
+++ b/Test/Unit/Helper/Export/ProductTest.php
@@ -106,7 +106,16 @@ class ProductTest extends TestCase
 
         $mockProductCollection = $this->createMock(ProductCollection::class);
         $mockProductCollection
+            ->expects($this->exactly(3))
             ->method('addAttributeToFilter')
+            ->withConsecutive(
+                ['type_id', ['eq' => 'simple']],
+                ['orderflow_export_date', ['null' => true]],
+                [[
+                    ['attribute' => 'orderflow_export_status', 'null' => true],
+                    ['attribute' => 'orderflow_export_status', 'nin' => ['Queued', 'Disabled']],
+                ], '', 'left']
+            )
             ->willReturnSelf();
 
         $mockProductCollection

--- a/Test/Unit/Model/Indexer/ProductReindexerTest.php
+++ b/Test/Unit/Model/Indexer/ProductReindexerTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Indexer;
+
+use Magento\Catalog\Model\ResourceModel\Product as ProductResourceModel;
+use Magento\Framework\Indexer\IndexerInterface;
+use Magento\Framework\Indexer\IndexerRegistry;
+use Magento\Framework\Module\Manager;
+use PHPUnit\Framework\TestCase;
+use RealtimeDespatch\OrderFlow\Model\Indexer\ProductReindexer;
+
+class ProductReindexerTest extends TestCase
+{
+    private Manager $moduleManager;
+    private IndexerRegistry $indexerRegistry;
+    private ProductResourceModel $productResource;
+    private ProductReindexer $reindexer;
+
+    protected function setUp(): void
+    {
+        $this->moduleManager = $this->createMock(Manager::class);
+        $this->indexerRegistry = $this->createMock(IndexerRegistry::class);
+        $this->productResource = $this->createMock(ProductResourceModel::class);
+
+        $this->reindexer = new ProductReindexer(
+            $this->moduleManager,
+            $this->indexerRegistry,
+            $this->productResource
+        );
+    }
+
+    public function testReindexSkusReturnsEarlyForEmptySkuList(): void
+    {
+        $this->moduleManager->expects($this->never())->method('isEnabled');
+        $this->productResource->expects($this->never())->method('getProductsIdsBySkus');
+
+        $this->reindexer->reindexSkus([]);
+    }
+
+    public function testReindexSkusReturnsEarlyWhenMsiIsDisabled(): void
+    {
+        $this->moduleManager
+            ->expects($this->once())
+            ->method('isEnabled')
+            ->with('Magento_InventoryApi')
+            ->willReturn(false);
+
+        $this->productResource->expects($this->never())->method('getProductsIdsBySkus');
+
+        $this->reindexer->reindexSkus(['ABC123']);
+    }
+
+    public function testReindexSkusReturnsEarlyWhenNoProductsAreResolved(): void
+    {
+        $this->moduleManager
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $this->productResource
+            ->expects($this->once())
+            ->method('getProductsIdsBySkus')
+            ->with(['ABC123'])
+            ->willReturn([]);
+
+        $this->indexerRegistry->expects($this->never())->method('get');
+
+        $this->reindexer->reindexSkus(['ABC123']);
+    }
+
+    public function testReindexSkusReindexesResolvedIdsAcrossAllIndexers(): void
+    {
+        $catalogInventoryIndexer = $this->createMock(IndexerInterface::class);
+        $catalogPriceIndexer = $this->createMock(IndexerInterface::class);
+        $catalogSearchIndexer = $this->createMock(IndexerInterface::class);
+
+        $this->moduleManager
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $this->productResource
+            ->expects($this->once())
+            ->method('getProductsIdsBySkus')
+            ->with(['ABC123', 'DEF456'])
+            ->willReturn([
+                'ABC123' => '10',
+                'DEF456' => 20,
+            ]);
+
+        $this->indexerRegistry
+            ->expects($this->exactly(3))
+            ->method('get')
+            ->willReturnMap([
+                ['cataloginventory_stock', $catalogInventoryIndexer],
+                ['catalog_product_price', $catalogPriceIndexer],
+                ['catalogsearch_fulltext', $catalogSearchIndexer],
+            ]);
+
+        $catalogInventoryIndexer
+            ->expects($this->once())
+            ->method('reindexList')
+            ->with([10, 20]);
+
+        $catalogPriceIndexer
+            ->expects($this->once())
+            ->method('reindexList')
+            ->with([10, 20]);
+
+        $catalogSearchIndexer
+            ->expects($this->once())
+            ->method('reindexList')
+            ->with([10, 20]);
+
+        $this->reindexer->reindexSkus(['ABC123', 'ABC123', 'DEF456']);
+    }
+}

--- a/Test/Unit/Model/Product/Attribute/Source/ExportStatusTest.php
+++ b/Test/Unit/Model/Product/Attribute/Source/ExportStatusTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Product\Attribute\Source;
+
+use RealtimeDespatch\OrderFlow\Model\Product\Attribute\Source\ExportStatus;
+
+class ExportStatusTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetAllOptionsIncludesDisabled(): void
+    {
+        $source = new ExportStatus();
+
+        $result = $source->getAllOptions();
+
+        $this->assertSame(
+            ['Pending', 'Queued', 'Exported', 'Failed', 'Disabled'],
+            array_map(static fn(array $option) => $option['value'], $result)
+        );
+    }
+}

--- a/Test/Unit/Model/Product/ExportStatus/OptionsTest.php
+++ b/Test/Unit/Model/Product/ExportStatus/OptionsTest.php
@@ -19,7 +19,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $result = $this->options->toOptionArray();
         $this->assertIsArray($result);
         $this->assertNotEmpty($result);
-        $expected = array_map(fn($x) => ['value' => $x, 'label' => $x], ['Pending', 'Queued', 'Exported', 'Failed']);
+        $expected = array_map(fn($x) => ['value' => $x, 'label' => $x], ['Pending', 'Queued', 'Exported', 'Failed', 'Disabled']);
         $this->assertEquals($expected, $result);
     }
 }

--- a/Test/Unit/Model/Product/ExportStatus/ProductExportStatusResolverTest.php
+++ b/Test/Unit/Model/Product/ExportStatus/ProductExportStatusResolverTest.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Product\ExportStatus;
+
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use PHPUnit\Framework\TestCase;
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
+
+class ProductExportStatusResolverTest extends TestCase
+{
+    private ProductExportStatusResolver $resolver;
+    private CollectionFactory $productCollectionFactory;
+    private Collection $productCollection;
+
+    protected function setUp(): void
+    {
+        $this->productCollectionFactory = $this->createMock(CollectionFactory::class);
+        $this->productCollection = $this->createMock(Collection::class);
+
+        $this->resolver = new ProductExportStatusResolver($this->productCollectionFactory);
+    }
+
+    public function testShouldSetPending(): void
+    {
+        $this->assertTrue($this->resolver->shouldSetPending('Queued', false));
+        $this->assertTrue($this->resolver->shouldSetPending(null, false));
+        $this->assertFalse($this->resolver->shouldSetPending('Disabled', false));
+        $this->assertFalse($this->resolver->shouldSetPending('Queued', true));
+    }
+
+    public function testGetProductIdsToSetPendingFiltersDisabledStatuses(): void
+    {
+        $enabledProduct = $this->createConfiguredMock(Product::class, [
+            'getData' => 'Queued',
+            'getId' => 10,
+        ]);
+        $disabledProduct = $this->createConfiguredMock(Product::class, [
+            'getData' => 'Disabled',
+            'getId' => 11,
+        ]);
+
+        $this->productCollectionFactory
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn($this->productCollection);
+
+        $this->productCollection
+            ->expects($this->once())
+            ->method('addIdFilter')
+            ->with([10, 11, 12])
+            ->willReturnSelf();
+
+        $this->productCollection
+            ->expects($this->once())
+            ->method('addAttributeToSelect')
+            ->with('orderflow_export_status')
+            ->willReturnSelf();
+
+        $this->productCollection
+            ->method('getIterator')
+            ->willReturn(new \ArrayIterator([$enabledProduct, $disabledProduct]));
+
+        $this->assertSame([10], $this->resolver->getProductIdsToSetPending([10, 11, 12, '10']));
+    }
+
+    public function testGetProductIdsBySkusToSetPendingFiltersDisabledStatuses(): void
+    {
+        $enabledProduct = $this->createConfiguredMock(Product::class, [
+            'getData' => null,
+            'getId' => 21,
+        ]);
+        $disabledProduct = $this->createConfiguredMock(Product::class, [
+            'getData' => 'Disabled',
+            'getId' => 22,
+        ]);
+
+        $this->productCollectionFactory
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn($this->productCollection);
+
+        $this->productCollection
+            ->expects($this->once())
+            ->method('addAttributeToSelect')
+            ->with('orderflow_export_status')
+            ->willReturnSelf();
+
+        $this->productCollection
+            ->expects($this->once())
+            ->method('addAttributeToFilter')
+            ->with('sku', ['in' => ['ABC', 'XYZ']])
+            ->willReturnSelf();
+
+        $this->productCollection
+            ->method('getIterator')
+            ->willReturn(new \ArrayIterator([$enabledProduct, $disabledProduct]));
+
+        $this->assertSame([21], $this->resolver->getProductIdsBySkusToSetPending(['ABC', 'XYZ', 'ABC', '']));
+    }
+
+    public function testGetSkusToSetPendingKeepsNewSkusAndRemovesDisabledOnes(): void
+    {
+        $enabledProduct = $this->createConfiguredMock(Product::class, [
+            'getData' => 'Queued',
+            'getSku' => 'ABC',
+        ]);
+        $disabledProduct = $this->createConfiguredMock(Product::class, [
+            'getData' => 'Disabled',
+            'getSku' => 'XYZ',
+        ]);
+
+        $this->productCollectionFactory
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn($this->productCollection);
+
+        $this->productCollection
+            ->expects($this->once())
+            ->method('addAttributeToSelect')
+            ->with('orderflow_export_status')
+            ->willReturnSelf();
+
+        $this->productCollection
+            ->expects($this->once())
+            ->method('addAttributeToFilter')
+            ->with('sku', ['in' => ['ABC', 'XYZ', 'NEW']])
+            ->willReturnSelf();
+
+        $this->productCollection
+            ->method('getIterator')
+            ->willReturn(new \ArrayIterator([$enabledProduct, $disabledProduct]));
+
+        $this->assertSame(['ABC', 'NEW'], $this->resolver->getSkusToSetPending(['ABC', 'XYZ', 'NEW']));
+    }
+}

--- a/Test/Unit/Model/Service/Export/Type/OrderExportExporterTypeTest.php
+++ b/Test/Unit/Model/Service/Export/Type/OrderExportExporterTypeTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Service\Export\Type;
 
+use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderRepository;
 use RealtimeDespatch\OrderFlow\Model\Factory\OrderFlow\Service\OrderServiceFactory;
@@ -13,12 +14,14 @@ use RealtimeDespatch\OrderFlow\Model\Service\Export\Type\OrderExportExporterType
 class OrderExportExporterTypeTest extends AbstractExporterTypeTest
 {
     protected Order $mockOrderRepository;
+    protected DateTime $mockDate;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->mockOrderRepository = $this->createMock(Order::class);
+        $this->mockDate = $this->createMock(DateTime::class);
 
         $this->mockOrderRepository
             ->method('loadByIncrementId')
@@ -29,7 +32,8 @@ class OrderExportExporterTypeTest extends AbstractExporterTypeTest
             $this->mockScopeConfig,
             $this->mockLogger,
             $this->mockObjectManager,
-            $this->mockOrderRepository
+            $this->mockOrderRepository,
+            $this->mockDate
         );
     }
 

--- a/Test/Unit/Model/Service/Export/Type/ProductExportExporterTypeTest.php
+++ b/Test/Unit/Model/Service/Export/Type/ProductExportExporterTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Service\Export\Type;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\OrderRepository;
 use RealtimeDespatch\OrderFlow\Model\Factory\OrderFlow\Service\OrderServiceFactory;
@@ -17,6 +18,7 @@ class ProductExportExporterTypeTest extends AbstractExporterTypeTest
 {
     protected ProductRepositoryInterface $mockProductRepository;
     protected ProductHelper $mockProductHelper;
+    protected DateTime $mockDate;
 
     protected function setUp(): void
     {
@@ -24,13 +26,15 @@ class ProductExportExporterTypeTest extends AbstractExporterTypeTest
 
         $this->mockProductRepository = $this->createMock(ProductRepositoryInterface::class);
         $this->mockProductHelper = $this->createMock(ProductHelper::class);
+        $this->mockDate = $this->createMock(DateTime::class);
 
         $this->exporterType = new ProductExportExporterType(
             $this->mockScopeConfig,
             $this->mockLogger,
             $this->mockObjectManager,
             $this->mockProductRepository,
-            $this->mockProductHelper
+            $this->mockProductHelper,
+            $this->mockDate
         );
     }
 

--- a/Test/Unit/Model/Service/Import/Type/InventoryUpdateImporterTypeTest.php
+++ b/Test/Unit/Model/Service/Import/Type/InventoryUpdateImporterTypeTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Service\Import\Type;
 
+use RealtimeDespatch\OrderFlow\Model\Indexer\ProductReindexer;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\ObjectManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -16,17 +17,20 @@ class InventoryUpdateImporterTypeTest extends AbstractImporterTypeTest
     protected StockHelper\MsiStockHelper $mockMsiStockHelper;
     protected StockHelper\LegacyStockHelper $mockLegacyStockHelper;
     protected StockHelperFactory $mockStockHelperFactory;
+    protected ProductReindexer $mockProductReindexer;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->mockStockHelperFactory = $this->createMock(StockHelperFactory::class);
+        $this->mockProductReindexer = $this->createMock(ProductReindexer::class);
 
         $this->type = new InventoryUpdateImporterType(
             $this->mockScopeConfig,
             $this->mockLogger,
             $this->mockObjectManager,
+            $this->mockProductReindexer,
             $this->mockStockHelperFactory
         );
     }

--- a/Test/Unit/Model/Source/Export/StatusTest.php
+++ b/Test/Unit/Model/Source/Export/StatusTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Source\Export;
+
+use RealtimeDespatch\OrderFlow\Model\Source\Export\Status;
+
+class StatusTest extends \PHPUnit\Framework\TestCase
+{
+    public function testToOptionArrayIncludesDisabled(): void
+    {
+        $source = new Status();
+
+        $result = $source->toOptionArray();
+
+        $this->assertSame(
+            ['Pending', 'Queued', 'Exported', 'Failed', 'Disabled'],
+            array_map(static fn(array $option) => $option['value'], $result)
+        );
+    }
+
+    public function testToArrayIncludesDisabled(): void
+    {
+        $source = new Status();
+
+        $result = $source->toArray();
+
+        $this->assertArrayHasKey('Disabled', $result);
+    }
+}

--- a/Test/Unit/Plugin/Catalog/ProductActionUpdateAttributesTest.php
+++ b/Test/Unit/Plugin/Catalog/ProductActionUpdateAttributesTest.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Plugin\Catalog;
+
+use Magento\Catalog\Model\Product\Action as ProductAction;
+use Magento\Catalog\Model\ResourceModel\Product\Action as ProductActionResource;
+use Magento\Store\Model\Store;
+use PHPUnit\Framework\TestCase;
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
+use RealtimeDespatch\OrderFlow\Plugin\Catalog\ProductActionUpdateAttributes;
+
+class ProductActionUpdateAttributesTest extends TestCase
+{
+    private ProductExportStatusResolver $productExportStatusResolver;
+    private ProductActionResource $productActionResource;
+    private ProductActionUpdateAttributes $plugin;
+    private ProductAction $subject;
+
+    protected function setUp(): void
+    {
+        $this->productExportStatusResolver = $this->createMock(ProductExportStatusResolver::class);
+        $this->productActionResource = $this->createMock(ProductActionResource::class);
+        $this->subject = $this->createMock(ProductAction::class);
+
+        $this->plugin = new ProductActionUpdateAttributes(
+            $this->productExportStatusResolver,
+            $this->productActionResource
+        );
+    }
+
+    public function testAroundUpdateAttributesSkipsWhenStatusIsExplicitlyUpdated(): void
+    {
+        $proceedCalls = 0;
+        $proceed = function ($productIds, $attrData, $storeId) use (&$proceedCalls) {
+            $proceedCalls++;
+            return 'result';
+        };
+
+        $this->productExportStatusResolver
+            ->expects($this->never())
+            ->method('getProductIdsToSetPending');
+
+        $this->productActionResource
+            ->expects($this->never())
+            ->method('updateAttributes');
+
+        $result = $this->plugin->aroundUpdateAttributes(
+            $this->subject,
+            $proceed,
+            [10, 11],
+            ['orderflow_export_status' => 'Queued'],
+            2
+        );
+
+        $this->assertSame('result', $result);
+        $this->assertSame(1, $proceedCalls);
+    }
+
+    public function testAroundUpdateAttributesFlagsEligibleProductsPending(): void
+    {
+        $proceedCalls = 0;
+        $proceed = function ($productIds, $attrData, $storeId) use (&$proceedCalls) {
+            $proceedCalls++;
+            return 'result';
+        };
+
+        $this->productExportStatusResolver
+            ->expects($this->once())
+            ->method('getProductIdsToSetPending')
+            ->with([10, 11, 12])
+            ->willReturn([10, 12]);
+
+        $this->productActionResource
+            ->expects($this->once())
+            ->method('updateAttributes')
+            ->with(
+                [10, 12],
+                ['orderflow_export_status' => ProductExportStatusResolver::STATUS_PENDING],
+                Store::DEFAULT_STORE_ID
+            );
+
+        $result = $this->plugin->aroundUpdateAttributes(
+            $this->subject,
+            $proceed,
+            [10, 11, 12],
+            ['name' => 'Updated Name'],
+            2
+        );
+
+        $this->assertSame('result', $result);
+        $this->assertSame(1, $proceedCalls);
+    }
+
+    public function testAroundUpdateAttributesSkipsWhenNoEligibleProductsRemain(): void
+    {
+        $proceed = fn ($productIds, $attrData, $storeId) => 'result';
+
+        $this->productExportStatusResolver
+            ->expects($this->once())
+            ->method('getProductIdsToSetPending')
+            ->with([10, 11])
+            ->willReturn([]);
+
+        $this->productActionResource
+            ->expects($this->never())
+            ->method('updateAttributes');
+
+        $result = $this->plugin->aroundUpdateAttributes(
+            $this->subject,
+            $proceed,
+            [10, 11],
+            ['visibility' => 4],
+            0
+        );
+
+        $this->assertSame('result', $result);
+    }
+}

--- a/Test/Unit/Plugin/Catalog/ProductSaveTest.php
+++ b/Test/Unit/Plugin/Catalog/ProductSaveTest.php
@@ -20,7 +20,7 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
         $this->mockProduct = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
             ->disableOriginalConstructor()
             ->addMethods(['setOrderflowExportStatus'])
-            ->onlyMethods(['isDataChanged', 'dataHasChangedFor'])
+            ->onlyMethods(['isDataChanged', 'dataHasChangedFor', 'getData'])
             ->getMock();
 
         $this->mockProductResource = $this->createMock(\Magento\Catalog\Model\ResourceModel\Product::class);
@@ -50,8 +50,47 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
 
         $this->mockProduct
             ->expects($this->once())
+            ->method('dataHasChangedFor')
+            ->with('orderflow_export_status')
+            ->willReturn(false);
+
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('getData')
+            ->with('orderflow_export_status')
+            ->willReturn('Queued');
+
+        $this->mockProduct
+            ->expects($this->once())
             ->method('setOrderflowExportStatus')
             ->with('Pending');
+
+        $result = $this->plugin->beforeSave($this->mockProductResource, $this->mockProduct);
+        $this->assertEquals($this->mockProduct, $result[0]);
+    }
+
+    public function testBeforeSaveDisabledStatusPreserved(): void
+    {
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('isDataChanged')
+            ->willReturn(true);
+
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('dataHasChangedFor')
+            ->with('orderflow_export_status')
+            ->willReturn(false);
+
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('getData')
+            ->with('orderflow_export_status')
+            ->willReturn('Disabled');
+
+        $this->mockProduct
+            ->expects($this->never())
+            ->method('setOrderflowExportStatus');
 
         $result = $this->plugin->beforeSave($this->mockProductResource, $this->mockProduct);
         $this->assertEquals($this->mockProduct, $result[0]);

--- a/Test/Unit/Plugin/Catalog/ProductSaveTest.php
+++ b/Test/Unit/Plugin/Catalog/ProductSaveTest.php
@@ -5,6 +5,7 @@ namespace RealtimeDespatch\OrderFlow\Test\Unit\Plugin\Catalog;
 
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
 use RealtimeDespatch\OrderFlow\Plugin\Catalog\ProductSave;
 
 class ProductSaveTest extends \PHPUnit\Framework\TestCase
@@ -12,10 +13,12 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
     protected ProductSave $plugin;
     protected Product $mockProduct;
     protected ProductResource $mockProductResource;
+    protected ProductExportStatusResolver $productExportStatusResolver;
 
     protected function setUp(): void
     {
-        $this->plugin = new ProductSave();
+        $this->productExportStatusResolver = $this->createMock(ProductExportStatusResolver::class);
+        $this->plugin = new ProductSave($this->productExportStatusResolver);
 
         $this->mockProduct = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
             ->disableOriginalConstructor()
@@ -32,6 +35,10 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('isDataChanged')
             ->willReturn(false);
+
+        $this->productExportStatusResolver
+            ->expects($this->never())
+            ->method('shouldSetPending');
 
         $this->mockProduct
             ->expects($this->never())
@@ -50,15 +57,21 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
 
         $this->mockProduct
             ->expects($this->once())
+            ->method('getData')
+            ->with('orderflow_export_status')
+            ->willReturn('Queued');
+
+        $this->mockProduct
+            ->expects($this->once())
             ->method('dataHasChangedFor')
             ->with('orderflow_export_status')
             ->willReturn(false);
 
-        $this->mockProduct
+        $this->productExportStatusResolver
             ->expects($this->once())
-            ->method('getData')
-            ->with('orderflow_export_status')
-            ->willReturn('Queued');
+            ->method('shouldSetPending')
+            ->with('Queued', false)
+            ->willReturn(true);
 
         $this->mockProduct
             ->expects($this->once())
@@ -78,15 +91,21 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
 
         $this->mockProduct
             ->expects($this->once())
+            ->method('getData')
+            ->with('orderflow_export_status')
+            ->willReturn('Disabled');
+
+        $this->mockProduct
+            ->expects($this->once())
             ->method('dataHasChangedFor')
             ->with('orderflow_export_status')
             ->willReturn(false);
 
-        $this->mockProduct
+        $this->productExportStatusResolver
             ->expects($this->once())
-            ->method('getData')
-            ->with('orderflow_export_status')
-            ->willReturn('Disabled');
+            ->method('shouldSetPending')
+            ->with('Disabled', false)
+            ->willReturn(false);
 
         $this->mockProduct
             ->expects($this->never())
@@ -108,6 +127,18 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
             ->method('dataHasChangedFor')
             ->with('orderflow_export_status')
             ->willReturn(true);
+
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('getData')
+            ->with('orderflow_export_status')
+            ->willReturn('Queued');
+
+        $this->productExportStatusResolver
+            ->expects($this->once())
+            ->method('shouldSetPending')
+            ->with('Queued', true)
+            ->willReturn(false);
 
         $this->mockProduct
             ->expects($this->never())

--- a/Test/Unit/Plugin/ImportExport/ImportDataPluginTest.php
+++ b/Test/Unit/Plugin/ImportExport/ImportDataPluginTest.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Plugin\ImportExport;
+
+use Magento\CatalogImportExport\Model\Import\Product as ProductImport;
+use Magento\ImportExport\Model\ResourceModel\Import\Data as ImportDataResource;
+use PHPUnit\Framework\TestCase;
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
+use RealtimeDespatch\OrderFlow\Plugin\ImportExport\ImportDataPlugin;
+
+class ImportDataPluginTest extends TestCase
+{
+    private const ENTITY_TYPE_CODE = 'catalog_product';
+
+    private ProductExportStatusResolver $productExportStatusResolver;
+    private ImportDataPlugin $plugin;
+    private ImportDataResource $importDataResource;
+
+    protected function setUp(): void
+    {
+        $this->productExportStatusResolver = $this->createMock(ProductExportStatusResolver::class);
+        $this->plugin = new ImportDataPlugin($this->productExportStatusResolver);
+        $this->importDataResource = $this->createMock(ImportDataResource::class);
+    }
+
+    public function testAfterGetNextUniqueBunchSkipsNonProductImports(): void
+    {
+        $bunch = [[ProductImport::COL_SKU => 'ABC']];
+        $ids = [11, 12];
+
+        $this->importDataResource
+            ->expects($this->once())
+            ->method('getEntityTypeCode')
+            ->with($ids)
+            ->willReturn('customer_main');
+
+        $this->productExportStatusResolver
+            ->expects($this->never())
+            ->method('getSkusToSetPending');
+
+        $this->assertSame($bunch, $this->plugin->afterGetNextUniqueBunch($this->importDataResource, $bunch, $ids));
+    }
+
+    public function testAfterGetNextUniqueBunchAddsPendingForEligibleProducts(): void
+    {
+        $bunch = [
+            [ProductImport::COL_SKU => 'ABC', 'name' => 'Updated Product'],
+            ['description' => 'Continuation row'],
+            [ProductImport::COL_SKU => 'XYZ', 'orderflow_export_status' => 'Queued'],
+            [ProductImport::COL_SKU => 'NEW-SKU', 'price' => '9.99'],
+        ];
+        $ids = [21, 22];
+
+        $this->importDataResource
+            ->expects($this->once())
+            ->method('getEntityTypeCode')
+            ->with($ids)
+            ->willReturn(self::ENTITY_TYPE_CODE);
+
+        $this->productExportStatusResolver
+            ->expects($this->once())
+            ->method('getSkusToSetPending')
+            ->with(['ABC', 'NEW-SKU'])
+            ->willReturn(['ABC', 'NEW-SKU']);
+
+        $result = $this->plugin->afterGetNextUniqueBunch($this->importDataResource, $bunch, $ids);
+
+        $this->assertSame(ProductExportStatusResolver::STATUS_PENDING, $result[0]['orderflow_export_status']);
+        $this->assertSame(ProductExportStatusResolver::STATUS_PENDING, $result[1]['orderflow_export_status']);
+        $this->assertSame('Queued', $result[2]['orderflow_export_status']);
+        $this->assertSame(ProductExportStatusResolver::STATUS_PENDING, $result[3]['orderflow_export_status']);
+    }
+
+    public function testAfterGetNextUniqueBunchSkipsWhenNoEligibleProductsRemain(): void
+    {
+        $bunch = [
+            [ProductImport::COL_SKU => 'ABC'],
+        ];
+        $ids = [31];
+
+        $this->importDataResource
+            ->expects($this->once())
+            ->method('getEntityTypeCode')
+            ->with($ids)
+            ->willReturn(self::ENTITY_TYPE_CODE);
+
+        $this->productExportStatusResolver
+            ->expects($this->once())
+            ->method('getSkusToSetPending')
+            ->with(['ABC'])
+            ->willReturn([]);
+
+        $this->assertSame($bunch, $this->plugin->afterGetNextUniqueBunch($this->importDataResource, $bunch, $ids));
+    }
+
+    public function testAfterGetNextBunchDelegatesToSameLogic(): void
+    {
+        $bunch = [
+            [ProductImport::COL_SKU => 'ABC'],
+        ];
+
+        $this->importDataResource
+            ->expects($this->once())
+            ->method('getEntityTypeCode')
+            ->with(null)
+            ->willReturn(self::ENTITY_TYPE_CODE);
+
+        $this->productExportStatusResolver
+            ->expects($this->once())
+            ->method('getSkusToSetPending')
+            ->with(['ABC'])
+            ->willReturn(['ABC']);
+
+        $result = $this->plugin->afterGetNextBunch($this->importDataResource, $bunch);
+
+        $this->assertSame(ProductExportStatusResolver::STATUS_PENDING, $result[0]['orderflow_export_status']);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -241,6 +241,12 @@
     <type name="\Magento\Webapi\Controller\Soap\Request\Handler">
         <plugin name="orderflow_soap_inventory_import_request" type="RealtimeDespatch\OrderFlow\Plugin\Webapi\Soap\InventoryImport"/>
     </type>
+    <type name="Magento\ImportExport\Model\ResourceModel\Import\Data">
+        <plugin name="orderflow_product_export_status_import" type="RealtimeDespatch\OrderFlow\Plugin\ImportExport\ImportDataPlugin"/>
+    </type>
+    <type name="Magento\Catalog\Model\Product\Action">
+        <plugin name="orderflow_product_export_status_mass_update" type="RealtimeDespatch\OrderFlow\Plugin\Catalog\ProductActionUpdateAttributes"/>
+    </type>
     <virtualType name="orderflowLogger" type="Magento\Framework\Logger\Monolog">
         <arguments>
             <argument name="handlers"  xsi:type="array">


### PR DESCRIPTION
## Title

Add product export status change detection for saves, mass updates, and imports

## Summary

This branch extends OrderFlow product export status handling so product changes are consistently marked for re-export across more update paths, while preserving the native `Disabled` status.

### What changed

- add a shared `ProductExportStatusResolver` to centralize the rules for when `orderflow_export_status` should be reset to `Pending`
- update the existing product save plugin to use the shared resolver instead of inline status logic
- add a plugin on `Magento\Catalog\Model\Product\Action::updateAttributes()` so mass attribute updates also mark eligible products as `Pending`
- add a plugin on `Magento\ImportExport\Model\ResourceModel\Import\Data` so product imports inject `orderflow_export_status=Pending` for eligible SKUs when the import row does not explicitly set a status
- wire the import plugin globally so it applies to product import execution paths beyond just the admin UI
- add focused unit coverage for the resolver, save plugin, mass-update plugin, and import plugin

### Behavior

- products already set to `Disabled` remain excluded from automatic reset to `Pending`
- explicit `orderflow_export_status` updates are preserved
- product edits now trigger re-export detection across:
  - individual product saves
  - mass attribute updates
  - product import batches

### Why

Previously, export status reset behavior was limited and inconsistent across different product update flows. This branch makes the change-detection behavior consistent so product changes are less likely to miss downstream OrderFlow export updates.
