### PR TITLE
Update phpunit bootstrap for portability

### DIFF
--- a/Api/Data/ProductInterface.php
+++ b/Api/Data/ProductInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace RealtimeDespatch\OrderFlow\Api\Data;
+
+/**
+ * Product export data interface.
+ *
+ * @api
+ */
+interface ProductInterface extends \Magento\Catalog\Api\Data\ProductInterface
+{
+    /**
+     * Get attribute set name.
+     *
+     * @return string|null
+     */
+    public function getAttributeSetName();
+
+    /**
+     * Set attribute set name.
+     *
+     * @param string $attributeSetName
+     *
+     * @return \RealtimeDespatch\OrderFlow\Api\Data\ProductInterface
+     */
+    public function setAttributeSetName($attributeSetName);
+}

--- a/Api/ProductRepositoryInterface.php
+++ b/Api/ProductRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace RealtimeDespatch\OrderFlow\Api;
+
+/**
+ * Product export repository interface.
+ *
+ * @api
+ */
+interface ProductRepositoryInterface
+{
+    /**
+     * Get info about product by SKU.
+     *
+     * @param string $sku
+     * @param int|null $storeId
+     *
+     * @return \RealtimeDespatch\OrderFlow\Api\Data\ProductInterface
+     */
+    public function get($sku, $storeId = null);
+}

--- a/Helper/Export/Order.php
+++ b/Helper/Export/Order.php
@@ -11,6 +11,7 @@ class Order extends \Magento\Framework\App\Helper\AbstractHelper
 {
     const STATUS_PENDING = 'Pending';
     const STATUS_QUEUED = 'Queued';
+    const STATUS_EXPORTED = 'Exported';
 
     /**
      * @var \Mage\Sales\Model\OrderFactory
@@ -132,7 +133,7 @@ class Order extends \Magento\Framework\App\Helper\AbstractHelper
             ->addFieldToFilter('is_virtual', ['eq' => 0])
             ->addFieldToFilter('orderflow_export_date', ['null' => true])
             ->addFieldToFilter('orderflow_export_status', [
-                ['nin' => [self::STATUS_QUEUED, 'Exported']],
+                ['nin' => [self::STATUS_QUEUED, self::STATUS_EXPORTED]],
                 ['null' => true],
             ])
             ->setPage(1, $this->getBatchSize($website->getId()));

--- a/Helper/Export/Product.php
+++ b/Helper/Export/Product.php
@@ -187,7 +187,7 @@ class Product extends \Magento\Framework\App\Helper\AbstractHelper
             ->addAttributeToFilter('orderflow_export_date', ['null' => true])
             ->addAttributeToFilter([
                 ['attribute' => 'orderflow_export_status', 'null' => true],
-                ['attribute' => 'orderflow_export_status', array('neq' => ['Queued'])],
+                ['attribute' => 'orderflow_export_status', 'nin' => ['Queued', 'Disabled']],
             ],
             '',
             'left')

--- a/Model/Data/Product.php
+++ b/Model/Data/Product.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace RealtimeDespatch\OrderFlow\Model\Data;
+
+use RealtimeDespatch\OrderFlow\Api\Data\ProductInterface;
+
+/**
+ * Product export data object.
+ *
+ * @api
+ */
+class Product extends \Magento\Catalog\Model\Product implements ProductInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function getAttributeSetName()
+    {
+        return $this->getData('attribute_set_name');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setAttributeSetName($attributeSetName)
+    {
+        return $this->setData('attribute_set_name', $attributeSetName);
+    }
+}

--- a/Model/Product/Attribute/Source/ExportStatus.php
+++ b/Model/Product/Attribute/Source/ExportStatus.php
@@ -18,7 +18,8 @@ class ExportStatus extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSo
             ['value' => 'Pending', 'label' => __('Pending')],
             ['value' => 'Queued', 'label' => __('Queued')],
             ['value' => 'Exported', 'label' => __('Exported')],
-            ['value' => 'Failed', 'label' => __('Failed')]
+            ['value' => 'Failed', 'label' => __('Failed')],
+            ['value' => 'Disabled', 'label' => __('Disabled')]
         ];
     }
 }

--- a/Model/Product/ExportStatus/Options.php
+++ b/Model/Product/ExportStatus/Options.php
@@ -31,6 +31,9 @@ class Options implements \Magento\Framework\Data\OptionSourceInterface
             array(
                 'value' => 'Failed', 'label' => 'Failed',
             ),
+            array(
+                'value' => 'Disabled', 'label' => 'Disabled',
+            ),
         );
     }
 }

--- a/Model/Product/ExportStatus/ProductExportStatusResolver.php
+++ b/Model/Product/ExportStatus/ProductExportStatusResolver.php
@@ -1,0 +1,148 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Model\Product\ExportStatus;
+
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+
+class ProductExportStatusResolver
+{
+    public const STATUS_PENDING = 'Pending';
+    public const STATUS_DISABLED = 'Disabled';
+
+    public function __construct(
+        private readonly CollectionFactory $productCollectionFactory
+    ) {}
+
+    public function shouldSetPending($currentStatus, bool $statusChangedExplicitly): bool
+    {
+        if ($statusChangedExplicitly) {
+            return false;
+        }
+
+        return $currentStatus !== self::STATUS_DISABLED;
+    }
+
+    /**
+     * @param mixed[] $productIds
+     * @return int[]
+     */
+    public function getProductIdsToSetPending(array $productIds): array
+    {
+        $productIds = $this->normalizeProductIds($productIds);
+        if ($productIds === []) {
+            return [];
+        }
+
+        $collection = $this->productCollectionFactory->create();
+        $collection->addIdFilter($productIds);
+        $collection->addAttributeToSelect('orderflow_export_status');
+
+        return $this->extractProductIdsToSetPending($collection);
+    }
+
+    /**
+     * @param mixed[] $skus
+     * @return int[]
+     */
+    public function getProductIdsBySkusToSetPending(array $skus): array
+    {
+        $skus = $this->normalizeSkus($skus);
+        if ($skus === []) {
+            return [];
+        }
+
+        $collection = $this->productCollectionFactory->create();
+        $collection->addAttributeToSelect('orderflow_export_status');
+        $collection->addAttributeToFilter('sku', ['in' => $skus]);
+
+        return $this->extractProductIdsToSetPending($collection);
+    }
+
+    /**
+     * @param mixed[] $skus
+     * @return string[]
+     */
+    public function getSkusToSetPending(array $skus): array
+    {
+        $skus = $this->normalizeSkus($skus);
+        if ($skus === []) {
+            return [];
+        }
+
+        $collection = $this->productCollectionFactory->create();
+        $collection->addAttributeToSelect('orderflow_export_status');
+        $collection->addAttributeToFilter('sku', ['in' => $skus]);
+
+        $eligibleSkus = array_fill_keys($skus, true);
+
+        foreach ($collection as $product) {
+            if (!$this->shouldSetPending($product->getData('orderflow_export_status'), false)) {
+                $sku = trim((string)$product->getSku());
+                if ($sku !== '') {
+                    unset($eligibleSkus[$sku]);
+                }
+            }
+        }
+
+        return array_values(array_keys($eligibleSkus));
+    }
+
+    /**
+     * @param mixed[] $productIds
+     * @return int[]
+     */
+    private function normalizeProductIds(array $productIds): array
+    {
+        $normalizedProductIds = [];
+
+        foreach ($productIds as $productId) {
+            $productId = (int)$productId;
+            if ($productId > 0) {
+                $normalizedProductIds[$productId] = $productId;
+            }
+        }
+
+        return array_values($normalizedProductIds);
+    }
+
+    /**
+     * @param mixed[] $skus
+     * @return string[]
+     */
+    private function normalizeSkus(array $skus): array
+    {
+        $normalizedSkus = [];
+
+        foreach ($skus as $sku) {
+            $sku = trim((string)$sku);
+            if ($sku !== '') {
+                $normalizedSkus[$sku] = $sku;
+            }
+        }
+
+        return array_values($normalizedSkus);
+    }
+
+    /**
+     * @param iterable<\Magento\Catalog\Api\Data\ProductInterface> $products
+     * @return int[]
+     */
+    private function extractProductIdsToSetPending(iterable $products): array
+    {
+        $eligibleProductIds = [];
+
+        foreach ($products as $product) {
+            if (!$this->shouldSetPending($product->getData('orderflow_export_status'), false)) {
+                continue;
+            }
+
+            $productId = (int)$product->getId();
+            if ($productId > 0) {
+                $eligibleProductIds[] = $productId;
+            }
+        }
+
+        return $eligibleProductIds;
+    }
+}

--- a/Model/ProductRepository.php
+++ b/Model/ProductRepository.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace RealtimeDespatch\OrderFlow\Model;
+
+use Magento\Catalog\Api\AttributeSetRepositoryInterface;
+use Magento\Catalog\Api\ProductAttributeManagementInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface as CatalogProductRepositoryInterface;
+use Magento\Eav\Api\AttributeRepositoryInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\ObjectManagerInterface;
+use RealtimeDespatch\OrderFlow\Api\ProductRepositoryInterface;
+
+/**
+ * OrderFlow product export repository.
+ */
+class ProductRepository implements ProductRepositoryInterface
+{
+    private const XML_PATH_USE_ATTRIBUTE_OPTION_LABELS = 'orderflow_product_export/settings/use_attribute_option_labels';
+
+    /**
+     * @var CatalogProductRepositoryInterface
+     */
+    protected $catalogProductRepository;
+
+    /**
+     * @var AttributeRepositoryInterface
+     */
+    protected $attributeRepository;
+
+    /**
+     * @var AttributeSetRepositoryInterface
+     */
+    protected $attributeSetRepository;
+
+    /**
+     * @var ProductAttributeManagementInterface
+     */
+    protected $productAttributeManagement;
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    /**
+     * @var array
+     */
+    protected $attributeOptionsMap = [];
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * @param CatalogProductRepositoryInterface $catalogProductRepository
+     * @param AttributeRepositoryInterface $attributeRepository
+     * @param AttributeSetRepositoryInterface $attributeSetRepository
+     * @param ProductAttributeManagementInterface $productAttributeManagement
+     * @param ObjectManagerInterface $objectManager
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        CatalogProductRepositoryInterface $catalogProductRepository,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeSetRepositoryInterface $attributeSetRepository,
+        ProductAttributeManagementInterface $productAttributeManagement,
+        ObjectManagerInterface $objectManager,
+        ScopeConfigInterface $scopeConfig
+    ) {
+        $this->catalogProductRepository = $catalogProductRepository;
+        $this->attributeRepository = $attributeRepository;
+        $this->attributeSetRepository = $attributeSetRepository;
+        $this->productAttributeManagement = $productAttributeManagement;
+        $this->objectManager = $objectManager;
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function get($sku, $storeId = null)
+    {
+        $product = $this->catalogProductRepository->get($sku, false, $storeId);
+        $attributeSet = $this->attributeSetRepository->get($product->getAttributeSetId());
+
+        if ($this->shouldUseAttributeOptionLabels()) {
+            $attributes = $this->productAttributeManagement->getAttributes($product->getAttributeSetId());
+
+            $sourceModelAttributes = array_filter($attributes, function ($attribute) {
+                return sizeof($attribute->getOptions()) > 0;
+            });
+
+            foreach ($sourceModelAttributes as $attribute) {
+                $attributeOptions = $this->getAttributeOptionsMap($attribute->getAttributeCode());
+                $value = $product->getData($attribute->getAttributeCode());
+
+                if ($attribute->getFrontendInput() == 'multiselect' && is_string($value)) {
+                    $value = explode(',', $value);
+                }
+
+                if (is_array($value)) {
+                    $newValue = [];
+                    foreach ($value as $optionValue) {
+                        $newValue[] = $attributeOptions[$optionValue] ?? $optionValue;
+                    }
+                    $product->setCustomAttribute($attribute->getAttributeCode(), $newValue);
+                } else {
+                    $product->setCustomAttribute($attribute->getAttributeCode(), $attributeOptions[$value] ?? $value);
+                }
+            }
+        }
+
+        $exportProduct = $this->objectManager->create(\RealtimeDespatch\OrderFlow\Model\Data\Product::class);
+        $exportProduct->setData($product->getData());
+        foreach ($product->getCustomAttributes() as $attributeCode => $customAttribute) {
+            if (is_object($customAttribute) && method_exists($customAttribute, 'getAttributeCode')) {
+                $attributeCode = $customAttribute->getAttributeCode();
+            }
+            if (!is_string($attributeCode) || $attributeCode === '') {
+                continue;
+            }
+            $value = $customAttribute;
+            if (is_object($customAttribute) && method_exists($customAttribute, 'getValue')) {
+                $value = $customAttribute->getValue();
+            }
+            $exportProduct->setCustomAttribute($attributeCode, $value);
+        }
+        if ($product->getExtensionAttributes() !== null) {
+            $exportProduct->setExtensionAttributes($product->getExtensionAttributes());
+        }
+        $exportProduct->setAttributeSetName($attributeSet->getAttributeSetName());
+
+        return $exportProduct;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function shouldUseAttributeOptionLabels()
+    {
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_USE_ATTRIBUTE_OPTION_LABELS);
+    }
+
+    /**
+     * @param string $attributeCode
+     *
+     * @return array
+     */
+    protected function getAttributeOptionsMap($attributeCode)
+    {
+        if (!isset($this->attributeOptionsMap[$attributeCode])) {
+            $attribute = $this->attributeRepository->get('catalog_product', $attributeCode);
+            $options = [];
+            foreach ($attribute->getOptions() as $option) {
+                $options[$option->getValue()] = (string)$option->getLabel();
+            }
+            $this->attributeOptionsMap[$attributeCode] = $options;
+        }
+
+        return $this->attributeOptionsMap[$attributeCode];
+    }
+}

--- a/Model/Source/Export/Status.php
+++ b/Model/Source/Export/Status.php
@@ -18,7 +18,8 @@ class Status implements \Magento\Framework\Option\ArrayInterface
             ['value' => 'Pending', 'label' => __('Pending')],
             ['value' => 'Queued', 'label' => __('Queued')],
             ['value' => 'Exported', 'label' => __('Exported')],
-            ['value' => 'Failed', 'label' => __('Failed')]
+            ['value' => 'Failed', 'label' => __('Failed')],
+            ['value' => 'Disabled', 'label' => __('Disabled')]
         ];
     }
 
@@ -27,6 +28,12 @@ class Status implements \Magento\Framework\Option\ArrayInterface
      */
     public function toArray()
     {
-        return ['Pending' => __('Pending'), 'Queued' => __('Queued'), 'Exported' => __('Exported'), 'Failed' => __('Failed')];
+        return [
+            'Pending' => __('Pending'),
+            'Queued' => __('Queued'),
+            'Exported' => __('Exported'),
+            'Failed' => __('Failed'),
+            'Disabled' => __('Disabled')
+        ];
     }
 }

--- a/Plugin/Catalog/ProductActionUpdateAttributes.php
+++ b/Plugin/Catalog/ProductActionUpdateAttributes.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Plugin\Catalog;
+
+use Magento\Catalog\Model\Product\Action as ProductAction;
+use Magento\Catalog\Model\ResourceModel\Product\Action as ProductActionResource;
+use Magento\Store\Model\Store;
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
+
+class ProductActionUpdateAttributes
+{
+    public function __construct(
+        private readonly ProductExportStatusResolver $productExportStatusResolver,
+        private readonly ProductActionResource $productActionResource
+    ) {}
+
+    public function aroundUpdateAttributes(
+        ProductAction $subject,
+        callable $proceed,
+        $productIds,
+        $attrData,
+        $storeId
+    ) {
+        $result = $proceed($productIds, $attrData, $storeId);
+
+        if (array_key_exists('orderflow_export_status', $attrData)) {
+            return $result;
+        }
+
+        $eligibleProductIds = $this->productExportStatusResolver->getProductIdsToSetPending((array)$productIds);
+        if ($eligibleProductIds === []) {
+            return $result;
+        }
+
+        $this->productActionResource->updateAttributes(
+            $eligibleProductIds,
+            ['orderflow_export_status' => ProductExportStatusResolver::STATUS_PENDING],
+            Store::DEFAULT_STORE_ID
+        );
+
+        return $result;
+    }
+}

--- a/Plugin/Catalog/ProductSave.php
+++ b/Plugin/Catalog/ProductSave.php
@@ -2,14 +2,17 @@
 
 namespace RealtimeDespatch\OrderFlow\Plugin\Catalog;
 
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
+
 /**
  * Class ProductSave
  * @package RealtimeDespatch\OrderFlow\Plugin\Catalog
  */
 class ProductSave
 {
-    const EXPORT_STATUS_PENDING = 'Pending';
-    const EXPORT_STATUS_DISABLED = 'Disabled';
+    public function __construct(
+        private readonly ProductExportStatusResolver $productExportStatusResolver
+    ) {}
 
     /**
      * Resets the Export Status if a product has been updated.
@@ -23,17 +26,15 @@ class ProductSave
             return array($product);
         }
 
-        // If a separate process has amended the export status ignore.
-        if ($product->dataHasChangedFor('orderflow_export_status')) {
-            return array($product);
-        }
-
-        if ($product->getData('orderflow_export_status') === self::EXPORT_STATUS_DISABLED) {
+        if (!$this->productExportStatusResolver->shouldSetPending(
+            $product->getData('orderflow_export_status'),
+            $product->dataHasChangedFor('orderflow_export_status')
+        )) {
             return array($product);
         }
 
         // Set pending export status.
-        $product->setOrderflowExportStatus(self::EXPORT_STATUS_PENDING);
+        $product->setOrderflowExportStatus(ProductExportStatusResolver::STATUS_PENDING);
 
         return array($product);
     }

--- a/Plugin/Catalog/ProductSave.php
+++ b/Plugin/Catalog/ProductSave.php
@@ -9,6 +9,7 @@ namespace RealtimeDespatch\OrderFlow\Plugin\Catalog;
 class ProductSave
 {
     const EXPORT_STATUS_PENDING = 'Pending';
+    const EXPORT_STATUS_DISABLED = 'Disabled';
 
     /**
      * Resets the Export Status if a product has been updated.
@@ -24,6 +25,10 @@ class ProductSave
 
         // If a separate process has amended the export status ignore.
         if ($product->dataHasChangedFor('orderflow_export_status')) {
+            return array($product);
+        }
+
+        if ($product->getData('orderflow_export_status') === self::EXPORT_STATUS_DISABLED) {
             return array($product);
         }
 

--- a/Plugin/ImportExport/ImportDataPlugin.php
+++ b/Plugin/ImportExport/ImportDataPlugin.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Plugin\ImportExport;
+
+use Magento\CatalogImportExport\Model\Import\Product as ProductImport;
+use Magento\ImportExport\Model\ResourceModel\Import\Data as ImportDataResource;
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
+
+class ImportDataPlugin
+{
+    private const ENTITY_TYPE_CODE = 'catalog_product';
+
+    public function __construct(
+        private readonly ProductExportStatusResolver $productExportStatusResolver
+    ) {}
+
+    public function afterGetNextBunch(ImportDataResource $subject, $result)
+    {
+        return $this->processBunch($subject, $result);
+    }
+
+    public function afterGetNextUniqueBunch(ImportDataResource $subject, $result, $ids = null)
+    {
+        return $this->processBunch($subject, $result, $ids);
+    }
+
+    private function processBunch(ImportDataResource $subject, $result, $ids = null)
+    {
+        if (!is_array($result) || $result === []) {
+            return $result;
+        }
+
+        if ($subject->getEntityTypeCode($ids) !== self::ENTITY_TYPE_CODE) {
+            return $result;
+        }
+
+        $currentSku = null;
+        $candidateSkus = [];
+        $explicitStatusSkus = [];
+
+        foreach ($result as $rowData) {
+            if (!is_array($rowData)) {
+                continue;
+            }
+
+            $rowSku = trim((string)($rowData[ProductImport::COL_SKU] ?? ''));
+            if ($rowSku !== '') {
+                $currentSku = $rowSku;
+            }
+
+            if ($currentSku === null) {
+                continue;
+            }
+
+            $candidateSkus[$currentSku] = $currentSku;
+
+            if (array_key_exists('orderflow_export_status', $rowData)) {
+                $explicitStatusSkus[$currentSku] = $currentSku;
+            }
+        }
+
+        if ($candidateSkus === []) {
+            return $result;
+        }
+
+        $candidateSkus = array_values(array_diff_key($candidateSkus, $explicitStatusSkus));
+        if ($candidateSkus === []) {
+            return $result;
+        }
+
+        $eligibleSkus = array_flip($this->productExportStatusResolver->getSkusToSetPending($candidateSkus));
+        if ($eligibleSkus === []) {
+            return $result;
+        }
+
+        $currentSku = null;
+        foreach ($result as $index => $rowData) {
+            if (!is_array($rowData)) {
+                continue;
+            }
+
+            $rowSku = trim((string)($rowData[ProductImport::COL_SKU] ?? ''));
+            if ($rowSku !== '') {
+                $currentSku = $rowSku;
+            }
+
+            if ($currentSku === null) {
+                continue;
+            }
+
+            if (array_key_exists('orderflow_export_status', $rowData)) {
+                continue;
+            }
+
+            if (!isset($eligibleSkus[$currentSku])) {
+                continue;
+            }
+
+            $rowData['orderflow_export_status'] = ProductExportStatusResolver::STATUS_PENDING;
+            $result[$index] = $rowData;
+        }
+
+        return $result;
+    }
+}

--- a/Plugin/Webapi/Soap/ProductExport.php
+++ b/Plugin/Webapi/Soap/ProductExport.php
@@ -5,6 +5,7 @@ namespace RealtimeDespatch\OrderFlow\Plugin\Webapi\Soap;
 class ProductExport
 {
     const OP_PRODUCT_EXPORT = 'catalogProductRepositoryV1Get';
+    const OP_ORDERFLOW_PRODUCT_EXPORT = 'realtimeDespatchOrderFlowProductRepositoryV1Get';
 
     /**
      * @var \Magento\Framework\ObjectManagerInterface
@@ -65,7 +66,7 @@ class ProductExport
      */
     protected function _isProductExport($operation)
     {
-        return $operation === self::OP_PRODUCT_EXPORT;
+        return in_array($operation, [self::OP_PRODUCT_EXPORT, self::OP_ORDERFLOW_PRODUCT_EXPORT], true);
     }
 
     /**

--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -117,7 +117,8 @@ class InstallData implements InstallDataInterface
                         'Pending',
                         'Queued',
                         'Exported',
-                        'Failed'
+                        'Failed',
+                        'Disabled'
                     ]
                 ]
             ]

--- a/Test/Unit/Helper/Export/ProductTest.php
+++ b/Test/Unit/Helper/Export/ProductTest.php
@@ -106,7 +106,16 @@ class ProductTest extends TestCase
 
         $mockProductCollection = $this->createMock(ProductCollection::class);
         $mockProductCollection
+            ->expects($this->exactly(3))
             ->method('addAttributeToFilter')
+            ->withConsecutive(
+                ['type_id', ['eq' => 'simple']],
+                ['orderflow_export_date', ['null' => true]],
+                [[
+                    ['attribute' => 'orderflow_export_status', 'null' => true],
+                    ['attribute' => 'orderflow_export_status', 'nin' => ['Queued', 'Disabled']],
+                ], '', 'left']
+            )
             ->willReturnSelf();
 
         $mockProductCollection

--- a/Test/Unit/Model/Indexer/ProductReindexerTest.php
+++ b/Test/Unit/Model/Indexer/ProductReindexerTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Indexer;
+
+use Magento\Catalog\Model\ResourceModel\Product as ProductResourceModel;
+use Magento\Framework\Indexer\IndexerInterface;
+use Magento\Framework\Indexer\IndexerRegistry;
+use Magento\Framework\Module\Manager;
+use PHPUnit\Framework\TestCase;
+use RealtimeDespatch\OrderFlow\Model\Indexer\ProductReindexer;
+
+class ProductReindexerTest extends TestCase
+{
+    private Manager $moduleManager;
+    private IndexerRegistry $indexerRegistry;
+    private ProductResourceModel $productResource;
+    private ProductReindexer $reindexer;
+
+    protected function setUp(): void
+    {
+        $this->moduleManager = $this->createMock(Manager::class);
+        $this->indexerRegistry = $this->createMock(IndexerRegistry::class);
+        $this->productResource = $this->createMock(ProductResourceModel::class);
+
+        $this->reindexer = new ProductReindexer(
+            $this->moduleManager,
+            $this->indexerRegistry,
+            $this->productResource
+        );
+    }
+
+    public function testReindexSkusReturnsEarlyForEmptySkuList(): void
+    {
+        $this->moduleManager->expects($this->never())->method('isEnabled');
+        $this->productResource->expects($this->never())->method('getProductsIdsBySkus');
+
+        $this->reindexer->reindexSkus([]);
+    }
+
+    public function testReindexSkusReturnsEarlyWhenMsiIsDisabled(): void
+    {
+        $this->moduleManager
+            ->expects($this->once())
+            ->method('isEnabled')
+            ->with('Magento_InventoryApi')
+            ->willReturn(false);
+
+        $this->productResource->expects($this->never())->method('getProductsIdsBySkus');
+
+        $this->reindexer->reindexSkus(['ABC123']);
+    }
+
+    public function testReindexSkusReturnsEarlyWhenNoProductsAreResolved(): void
+    {
+        $this->moduleManager
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $this->productResource
+            ->expects($this->once())
+            ->method('getProductsIdsBySkus')
+            ->with(['ABC123'])
+            ->willReturn([]);
+
+        $this->indexerRegistry->expects($this->never())->method('get');
+
+        $this->reindexer->reindexSkus(['ABC123']);
+    }
+
+    public function testReindexSkusReindexesResolvedIdsAcrossAllIndexers(): void
+    {
+        $catalogInventoryIndexer = $this->createMock(IndexerInterface::class);
+        $catalogPriceIndexer = $this->createMock(IndexerInterface::class);
+        $catalogSearchIndexer = $this->createMock(IndexerInterface::class);
+
+        $this->moduleManager
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $this->productResource
+            ->expects($this->once())
+            ->method('getProductsIdsBySkus')
+            ->with(['ABC123', 'DEF456'])
+            ->willReturn([
+                'ABC123' => '10',
+                'DEF456' => 20,
+            ]);
+
+        $this->indexerRegistry
+            ->expects($this->exactly(3))
+            ->method('get')
+            ->willReturnMap([
+                ['cataloginventory_stock', $catalogInventoryIndexer],
+                ['catalog_product_price', $catalogPriceIndexer],
+                ['catalogsearch_fulltext', $catalogSearchIndexer],
+            ]);
+
+        $catalogInventoryIndexer
+            ->expects($this->once())
+            ->method('reindexList')
+            ->with([10, 20]);
+
+        $catalogPriceIndexer
+            ->expects($this->once())
+            ->method('reindexList')
+            ->with([10, 20]);
+
+        $catalogSearchIndexer
+            ->expects($this->once())
+            ->method('reindexList')
+            ->with([10, 20]);
+
+        $this->reindexer->reindexSkus(['ABC123', 'ABC123', 'DEF456']);
+    }
+}

--- a/Test/Unit/Model/Product/Attribute/Source/ExportStatusTest.php
+++ b/Test/Unit/Model/Product/Attribute/Source/ExportStatusTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Product\Attribute\Source;
+
+use RealtimeDespatch\OrderFlow\Model\Product\Attribute\Source\ExportStatus;
+
+class ExportStatusTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGetAllOptionsIncludesDisabled(): void
+    {
+        $source = new ExportStatus();
+
+        $result = $source->getAllOptions();
+
+        $this->assertSame(
+            ['Pending', 'Queued', 'Exported', 'Failed', 'Disabled'],
+            array_map(static fn(array $option) => $option['value'], $result)
+        );
+    }
+}

--- a/Test/Unit/Model/Product/ExportStatus/OptionsTest.php
+++ b/Test/Unit/Model/Product/ExportStatus/OptionsTest.php
@@ -19,7 +19,7 @@ class OptionsTest extends \PHPUnit\Framework\TestCase
         $result = $this->options->toOptionArray();
         $this->assertIsArray($result);
         $this->assertNotEmpty($result);
-        $expected = array_map(fn($x) => ['value' => $x, 'label' => $x], ['Pending', 'Queued', 'Exported', 'Failed']);
+        $expected = array_map(fn($x) => ['value' => $x, 'label' => $x], ['Pending', 'Queued', 'Exported', 'Failed', 'Disabled']);
         $this->assertEquals($expected, $result);
     }
 }

--- a/Test/Unit/Model/Product/ExportStatus/ProductExportStatusResolverTest.php
+++ b/Test/Unit/Model/Product/ExportStatus/ProductExportStatusResolverTest.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Product\ExportStatus;
+
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use PHPUnit\Framework\TestCase;
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
+
+class ProductExportStatusResolverTest extends TestCase
+{
+    private ProductExportStatusResolver $resolver;
+    private CollectionFactory $productCollectionFactory;
+    private Collection $productCollection;
+
+    protected function setUp(): void
+    {
+        $this->productCollectionFactory = $this->createMock(CollectionFactory::class);
+        $this->productCollection = $this->createMock(Collection::class);
+
+        $this->resolver = new ProductExportStatusResolver($this->productCollectionFactory);
+    }
+
+    public function testShouldSetPending(): void
+    {
+        $this->assertTrue($this->resolver->shouldSetPending('Queued', false));
+        $this->assertTrue($this->resolver->shouldSetPending(null, false));
+        $this->assertFalse($this->resolver->shouldSetPending('Disabled', false));
+        $this->assertFalse($this->resolver->shouldSetPending('Queued', true));
+    }
+
+    public function testGetProductIdsToSetPendingFiltersDisabledStatuses(): void
+    {
+        $enabledProduct = $this->createConfiguredMock(Product::class, [
+            'getData' => 'Queued',
+            'getId' => 10,
+        ]);
+        $disabledProduct = $this->createConfiguredMock(Product::class, [
+            'getData' => 'Disabled',
+            'getId' => 11,
+        ]);
+
+        $this->productCollectionFactory
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn($this->productCollection);
+
+        $this->productCollection
+            ->expects($this->once())
+            ->method('addIdFilter')
+            ->with([10, 11, 12])
+            ->willReturnSelf();
+
+        $this->productCollection
+            ->expects($this->once())
+            ->method('addAttributeToSelect')
+            ->with('orderflow_export_status')
+            ->willReturnSelf();
+
+        $this->productCollection
+            ->method('getIterator')
+            ->willReturn(new \ArrayIterator([$enabledProduct, $disabledProduct]));
+
+        $this->assertSame([10], $this->resolver->getProductIdsToSetPending([10, 11, 12, '10']));
+    }
+
+    public function testGetProductIdsBySkusToSetPendingFiltersDisabledStatuses(): void
+    {
+        $enabledProduct = $this->createConfiguredMock(Product::class, [
+            'getData' => null,
+            'getId' => 21,
+        ]);
+        $disabledProduct = $this->createConfiguredMock(Product::class, [
+            'getData' => 'Disabled',
+            'getId' => 22,
+        ]);
+
+        $this->productCollectionFactory
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn($this->productCollection);
+
+        $this->productCollection
+            ->expects($this->once())
+            ->method('addAttributeToSelect')
+            ->with('orderflow_export_status')
+            ->willReturnSelf();
+
+        $this->productCollection
+            ->expects($this->once())
+            ->method('addAttributeToFilter')
+            ->with('sku', ['in' => ['ABC', 'XYZ']])
+            ->willReturnSelf();
+
+        $this->productCollection
+            ->method('getIterator')
+            ->willReturn(new \ArrayIterator([$enabledProduct, $disabledProduct]));
+
+        $this->assertSame([21], $this->resolver->getProductIdsBySkusToSetPending(['ABC', 'XYZ', 'ABC', '']));
+    }
+
+    public function testGetSkusToSetPendingKeepsNewSkusAndRemovesDisabledOnes(): void
+    {
+        $enabledProduct = $this->createConfiguredMock(Product::class, [
+            'getData' => 'Queued',
+            'getSku' => 'ABC',
+        ]);
+        $disabledProduct = $this->createConfiguredMock(Product::class, [
+            'getData' => 'Disabled',
+            'getSku' => 'XYZ',
+        ]);
+
+        $this->productCollectionFactory
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn($this->productCollection);
+
+        $this->productCollection
+            ->expects($this->once())
+            ->method('addAttributeToSelect')
+            ->with('orderflow_export_status')
+            ->willReturnSelf();
+
+        $this->productCollection
+            ->expects($this->once())
+            ->method('addAttributeToFilter')
+            ->with('sku', ['in' => ['ABC', 'XYZ', 'NEW']])
+            ->willReturnSelf();
+
+        $this->productCollection
+            ->method('getIterator')
+            ->willReturn(new \ArrayIterator([$enabledProduct, $disabledProduct]));
+
+        $this->assertSame(['ABC', 'NEW'], $this->resolver->getSkusToSetPending(['ABC', 'XYZ', 'NEW']));
+    }
+}

--- a/Test/Unit/Model/ProductRepositoryTest.php
+++ b/Test/Unit/Model/ProductRepositoryTest.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model;
+
+use Magento\Catalog\Api\AttributeSetRepositoryInterface;
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
+use Magento\Catalog\Api\Data\ProductCustomOptionInterface;
+use Magento\Catalog\Api\ProductAttributeManagementInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface as CatalogProductRepositoryInterface;
+use Magento\Eav\Api\AttributeRepositoryInterface;
+use Magento\Eav\Api\Data\AttributeOptionInterface;
+use Magento\Eav\Api\Data\AttributeSetInterface;
+use Magento\Framework\Api\AttributeValue;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\ObjectManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RealtimeDespatch\OrderFlow\Model\Data\Product;
+use RealtimeDespatch\OrderFlow\Model\ProductRepository;
+
+class ProductRepositoryTest extends TestCase
+{
+    /**
+     * @var CatalogProductRepositoryInterface&MockObject
+     */
+    private $catalogProductRepository;
+
+    /**
+     * @var AttributeRepositoryInterface&MockObject
+     */
+    private $attributeRepository;
+
+    /**
+     * @var AttributeSetRepositoryInterface&MockObject
+     */
+    private $attributeSetRepository;
+
+    /**
+     * @var ProductAttributeManagementInterface&MockObject
+     */
+    private $productAttributeManagement;
+
+    /**
+     * @var ObjectManagerInterface&MockObject
+     */
+    private $objectManager;
+
+    /**
+     * @var ScopeConfigInterface&MockObject
+     */
+    private $scopeConfig;
+
+    /**
+     * @var ProductRepository
+     */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        $this->catalogProductRepository = $this->createMock(CatalogProductRepositoryInterface::class);
+        $this->attributeRepository = $this->createMock(AttributeRepositoryInterface::class);
+        $this->attributeSetRepository = $this->createMock(AttributeSetRepositoryInterface::class);
+        $this->productAttributeManagement = $this->createMock(ProductAttributeManagementInterface::class);
+        $this->objectManager = $this->createMock(ObjectManagerInterface::class);
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+
+        $this->repository = new ProductRepository(
+            $this->catalogProductRepository,
+            $this->attributeRepository,
+            $this->attributeSetRepository,
+            $this->productAttributeManagement,
+            $this->objectManager,
+            $this->scopeConfig
+        );
+    }
+
+    public function testGetReturnsMappedOptionLabelsAndAttributeSetName(): void
+    {
+        $product = $this->createMock(\Magento\Catalog\Model\Product::class);
+        $exportProduct = $this->createMock(Product::class);
+        $colorAttribute = $this->createConfiguredMock(ProductAttributeInterface::class, [
+            'getAttributeCode' => 'color',
+            'getFrontendInput' => 'select',
+            'getOptions' => [$this->createMock(ProductCustomOptionInterface::class)],
+        ]);
+        $materialAttribute = $this->createConfiguredMock(ProductAttributeInterface::class, [
+            'getAttributeCode' => 'material',
+            'getFrontendInput' => 'multiselect',
+            'getOptions' => [$this->createMock(ProductCustomOptionInterface::class)],
+        ]);
+        $attributeSet = $this->createConfiguredMock(AttributeSetInterface::class, [
+            'getAttributeSetName' => 'Fabric',
+        ]);
+
+        $colorOptions = [
+            $this->createOption('12', 'Blue'),
+        ];
+        $materialOptions = [
+            $this->createOption('5', 'Cotton'),
+            $this->createOption('7', 'Linen'),
+        ];
+
+        $this->catalogProductRepository->expects($this->once())
+            ->method('get')
+            ->with('SKU-1', false, null)
+            ->willReturn($product);
+        $this->scopeConfig->expects($this->once())
+            ->method('isSetFlag')
+            ->with('orderflow_product_export/settings/use_attribute_option_labels')
+            ->willReturn(true);
+        $product->method('getAttributeSetId')->willReturn(42);
+        $this->productAttributeManagement->expects($this->once())
+            ->method('getAttributes')
+            ->with(42)
+            ->willReturn([$colorAttribute, $materialAttribute]);
+        $this->attributeSetRepository->expects($this->once())
+            ->method('get')
+            ->with(42)
+            ->willReturn($attributeSet);
+        $this->attributeRepository->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnMap([
+                ['catalog_product', 'color', $this->createAttributeWithOptions($colorOptions)],
+                ['catalog_product', 'material', $this->createAttributeWithOptions($materialOptions)],
+            ]);
+        $product->method('getData')
+            ->willReturnCallback(function (...$args) {
+                $key = $args[0] ?? null;
+                if ($key === 'color') {
+                    return '12';
+                }
+                if ($key === 'material') {
+                    return '5,7';
+                }
+                if ($key === null) {
+                    return ['sku' => 'SKU-1', 'attribute_set_id' => 42];
+                }
+
+                return null;
+            });
+        $product->expects($this->exactly(2))
+            ->method('setCustomAttribute')
+            ->withConsecutive(
+                ['color', 'Blue'],
+                ['material', ['Cotton', 'Linen']]
+            );
+        $product->expects($this->once())
+            ->method('getCustomAttributes')
+            ->willReturn([
+                $this->createConfiguredMock(AttributeValue::class, [
+                    'getAttributeCode' => 'color',
+                    'getValue' => 'Blue',
+                ]),
+                $this->createConfiguredMock(AttributeValue::class, [
+                    'getAttributeCode' => 'material',
+                    'getValue' => ['Cotton', 'Linen'],
+                ]),
+            ]);
+        $product->expects($this->once())
+            ->method('getExtensionAttributes')
+            ->willReturn(null);
+
+        $this->objectManager->expects($this->once())
+            ->method('create')
+            ->with(Product::class)
+            ->willReturn($exportProduct);
+        $exportProduct->expects($this->once())
+            ->method('setData')
+            ->willReturnSelf();
+        $exportProduct->expects($this->exactly(2))
+            ->method('setCustomAttribute')
+            ->withConsecutive(
+                ['color', 'Blue'],
+                ['material', ['Cotton', 'Linen']]
+            )
+            ->willReturnSelf();
+        $exportProduct->expects($this->once())
+            ->method('setAttributeSetName')
+            ->with('Fabric')
+            ->willReturnSelf();
+
+        $result = $this->repository->get('SKU-1');
+
+        $this->assertSame($exportProduct, $result);
+    }
+
+    public function testGetFallsBackToRawOptionValueWhenNoLabelExists(): void
+    {
+        $product = $this->createMock(\Magento\Catalog\Model\Product::class);
+        $exportProduct = $this->createMock(Product::class);
+        $attribute = $this->createConfiguredMock(ProductAttributeInterface::class, [
+            'getAttributeCode' => 'color',
+            'getFrontendInput' => 'select',
+            'getOptions' => [$this->createMock(ProductCustomOptionInterface::class)],
+        ]);
+        $attributeSet = $this->createConfiguredMock(AttributeSetInterface::class, [
+            'getAttributeSetName' => 'Default',
+        ]);
+
+        $this->catalogProductRepository->method('get')->willReturn($product);
+        $this->scopeConfig->expects($this->once())
+            ->method('isSetFlag')
+            ->with('orderflow_product_export/settings/use_attribute_option_labels')
+            ->willReturn(true);
+        $product->method('getAttributeSetId')->willReturn(3);
+        $this->productAttributeManagement->method('getAttributes')->willReturn([$attribute]);
+        $this->attributeSetRepository->method('get')->willReturn($attributeSet);
+        $this->attributeRepository->method('get')->willReturn($this->createAttributeWithOptions([]));
+        $product->method('getData')
+            ->willReturnCallback(function (...$args) {
+                $key = $args[0] ?? null;
+                if ($key === 'color') {
+                    return '999';
+                }
+                if ($key === null) {
+                    return ['sku' => 'SKU-2', 'attribute_set_id' => 3];
+                }
+
+                return null;
+            });
+        $product->expects($this->once())
+            ->method('setCustomAttribute')
+            ->with('color', '999');
+        $product->method('getCustomAttributes')->willReturn([]);
+        $product->method('getExtensionAttributes')->willReturn(null);
+
+        $this->objectManager->method('create')->with(Product::class)->willReturn($exportProduct);
+        $exportProduct->method('setData')->willReturnSelf();
+        $exportProduct->expects($this->never())->method('setCustomAttribute');
+        $exportProduct->method('setExtensionAttributes')->willReturnSelf();
+        $exportProduct->method('setAttributeSetName')->willReturnSelf();
+
+        $this->assertSame($exportProduct, $this->repository->get('SKU-2'));
+    }
+
+    public function testGetSkipsAttributeValueMappingWhenConfigDisabled(): void
+    {
+        $product = $this->createMock(\Magento\Catalog\Model\Product::class);
+        $exportProduct = $this->createMock(Product::class);
+        $attributeSet = $this->createConfiguredMock(AttributeSetInterface::class, [
+            'getAttributeSetName' => 'Default',
+        ]);
+
+        $this->catalogProductRepository->expects($this->once())
+            ->method('get')
+            ->with('SKU-3', false, null)
+            ->willReturn($product);
+        $this->scopeConfig->expects($this->once())
+            ->method('isSetFlag')
+            ->with('orderflow_product_export/settings/use_attribute_option_labels')
+            ->willReturn(false);
+        $product->method('getAttributeSetId')->willReturn(9);
+        $this->productAttributeManagement->expects($this->never())->method('getAttributes');
+        $this->attributeRepository->expects($this->never())->method('get');
+        $product->expects($this->never())->method('setCustomAttribute');
+        $this->attributeSetRepository->expects($this->once())
+            ->method('get')
+            ->with(9)
+            ->willReturn($attributeSet);
+        $product->method('getData')->willReturn(['sku' => 'SKU-3', 'attribute_set_id' => 9]);
+        $product->method('getCustomAttributes')->willReturn([]);
+        $product->method('getExtensionAttributes')->willReturn(null);
+
+        $this->objectManager->expects($this->once())
+            ->method('create')
+            ->with(Product::class)
+            ->willReturn($exportProduct);
+        $exportProduct->expects($this->once())->method('setData')->willReturnSelf();
+        $exportProduct->expects($this->never())->method('setCustomAttribute');
+        $exportProduct->expects($this->once())->method('setAttributeSetName')->with('Default')->willReturnSelf();
+
+        $this->assertSame($exportProduct, $this->repository->get('SKU-3'));
+    }
+
+    public function testGetCopiesSequentialCustomAttributesToExportProduct(): void
+    {
+        $product = $this->createMock(\Magento\Catalog\Model\Product::class);
+        $exportProduct = $this->createMock(Product::class);
+        $attributeSet = $this->createConfiguredMock(AttributeSetInterface::class, [
+            'getAttributeSetName' => 'Default',
+        ]);
+
+        $this->catalogProductRepository->expects($this->once())
+            ->method('get')
+            ->with('SKU-4', false, null)
+            ->willReturn($product);
+        $this->scopeConfig->expects($this->once())
+            ->method('isSetFlag')
+            ->with('orderflow_product_export/settings/use_attribute_option_labels')
+            ->willReturn(false);
+        $product->method('getAttributeSetId')->willReturn(11);
+        $this->productAttributeManagement->expects($this->never())->method('getAttributes');
+        $this->attributeSetRepository->expects($this->once())->method('get')->with(11)->willReturn($attributeSet);
+        $product->method('getData')->willReturn(['sku' => 'SKU-4', 'attribute_set_id' => 11]);
+        $product->method('getCustomAttributes')->willReturn([
+            $this->createConfiguredMock(AttributeValue::class, [
+                'getAttributeCode' => 'brand',
+                'getValue' => 'Sirdar',
+            ]),
+            $this->createConfiguredMock(AttributeValue::class, [
+                'getAttributeCode' => 'condition',
+                'getValue' => 'New',
+            ]),
+        ]);
+        $product->method('getExtensionAttributes')->willReturn(null);
+
+        $this->objectManager->expects($this->once())
+            ->method('create')
+            ->with(Product::class)
+            ->willReturn($exportProduct);
+        $exportProduct->expects($this->once())->method('setData')->willReturnSelf();
+        $exportProduct->expects($this->exactly(2))
+            ->method('setCustomAttribute')
+            ->withConsecutive(
+                ['brand', 'Sirdar'],
+                ['condition', 'New']
+            )
+            ->willReturnSelf();
+        $exportProduct->expects($this->once())->method('setAttributeSetName')->with('Default')->willReturnSelf();
+
+        $this->assertSame($exportProduct, $this->repository->get('SKU-4'));
+    }
+
+    private function createOption(string $value, string $label): AttributeOptionInterface
+    {
+        return $this->createConfiguredMock(AttributeOptionInterface::class, [
+            'getValue' => $value,
+            'getLabel' => $label,
+        ]);
+    }
+
+    private function createAttributeWithOptions(array $options): \Magento\Catalog\Api\Data\ProductAttributeInterface
+    {
+        return $this->createConfiguredMock(ProductAttributeInterface::class, [
+            'getOptions' => $options,
+        ]);
+    }
+}

--- a/Test/Unit/Model/Service/Export/Type/OrderExportExporterTypeTest.php
+++ b/Test/Unit/Model/Service/Export/Type/OrderExportExporterTypeTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Service\Export\Type;
 
+use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderRepository;
 use RealtimeDespatch\OrderFlow\Model\Factory\OrderFlow\Service\OrderServiceFactory;
@@ -13,12 +14,14 @@ use RealtimeDespatch\OrderFlow\Model\Service\Export\Type\OrderExportExporterType
 class OrderExportExporterTypeTest extends AbstractExporterTypeTest
 {
     protected Order $mockOrderRepository;
+    protected DateTime $mockDate;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->mockOrderRepository = $this->createMock(Order::class);
+        $this->mockDate = $this->createMock(DateTime::class);
 
         $this->mockOrderRepository
             ->method('loadByIncrementId')
@@ -29,7 +32,8 @@ class OrderExportExporterTypeTest extends AbstractExporterTypeTest
             $this->mockScopeConfig,
             $this->mockLogger,
             $this->mockObjectManager,
-            $this->mockOrderRepository
+            $this->mockOrderRepository,
+            $this->mockDate
         );
     }
 

--- a/Test/Unit/Model/Service/Export/Type/ProductExportExporterTypeTest.php
+++ b/Test/Unit/Model/Service/Export/Type/ProductExportExporterTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Service\Export\Type;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\OrderRepository;
 use RealtimeDespatch\OrderFlow\Model\Factory\OrderFlow\Service\OrderServiceFactory;
@@ -17,6 +18,7 @@ class ProductExportExporterTypeTest extends AbstractExporterTypeTest
 {
     protected ProductRepositoryInterface $mockProductRepository;
     protected ProductHelper $mockProductHelper;
+    protected DateTime $mockDate;
 
     protected function setUp(): void
     {
@@ -24,13 +26,15 @@ class ProductExportExporterTypeTest extends AbstractExporterTypeTest
 
         $this->mockProductRepository = $this->createMock(ProductRepositoryInterface::class);
         $this->mockProductHelper = $this->createMock(ProductHelper::class);
+        $this->mockDate = $this->createMock(DateTime::class);
 
         $this->exporterType = new ProductExportExporterType(
             $this->mockScopeConfig,
             $this->mockLogger,
             $this->mockObjectManager,
             $this->mockProductRepository,
-            $this->mockProductHelper
+            $this->mockProductHelper,
+            $this->mockDate
         );
     }
 

--- a/Test/Unit/Model/Service/Import/Type/InventoryUpdateImporterTypeTest.php
+++ b/Test/Unit/Model/Service/Import/Type/InventoryUpdateImporterTypeTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Service\Import\Type;
 
+use RealtimeDespatch\OrderFlow\Model\Indexer\ProductReindexer;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\ObjectManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -16,17 +17,20 @@ class InventoryUpdateImporterTypeTest extends AbstractImporterTypeTest
     protected StockHelper\MsiStockHelper $mockMsiStockHelper;
     protected StockHelper\LegacyStockHelper $mockLegacyStockHelper;
     protected StockHelperFactory $mockStockHelperFactory;
+    protected ProductReindexer $mockProductReindexer;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->mockStockHelperFactory = $this->createMock(StockHelperFactory::class);
+        $this->mockProductReindexer = $this->createMock(ProductReindexer::class);
 
         $this->type = new InventoryUpdateImporterType(
             $this->mockScopeConfig,
             $this->mockLogger,
             $this->mockObjectManager,
+            $this->mockProductReindexer,
             $this->mockStockHelperFactory
         );
     }

--- a/Test/Unit/Model/Source/Export/StatusTest.php
+++ b/Test/Unit/Model/Source/Export/StatusTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Model\Source\Export;
+
+use RealtimeDespatch\OrderFlow\Model\Source\Export\Status;
+
+class StatusTest extends \PHPUnit\Framework\TestCase
+{
+    public function testToOptionArrayIncludesDisabled(): void
+    {
+        $source = new Status();
+
+        $result = $source->toOptionArray();
+
+        $this->assertSame(
+            ['Pending', 'Queued', 'Exported', 'Failed', 'Disabled'],
+            array_map(static fn(array $option) => $option['value'], $result)
+        );
+    }
+
+    public function testToArrayIncludesDisabled(): void
+    {
+        $source = new Status();
+
+        $result = $source->toArray();
+
+        $this->assertArrayHasKey('Disabled', $result);
+    }
+}

--- a/Test/Unit/Plugin/Catalog/ProductActionUpdateAttributesTest.php
+++ b/Test/Unit/Plugin/Catalog/ProductActionUpdateAttributesTest.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Plugin\Catalog;
+
+use Magento\Catalog\Model\Product\Action as ProductAction;
+use Magento\Catalog\Model\ResourceModel\Product\Action as ProductActionResource;
+use Magento\Store\Model\Store;
+use PHPUnit\Framework\TestCase;
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
+use RealtimeDespatch\OrderFlow\Plugin\Catalog\ProductActionUpdateAttributes;
+
+class ProductActionUpdateAttributesTest extends TestCase
+{
+    private ProductExportStatusResolver $productExportStatusResolver;
+    private ProductActionResource $productActionResource;
+    private ProductActionUpdateAttributes $plugin;
+    private ProductAction $subject;
+
+    protected function setUp(): void
+    {
+        $this->productExportStatusResolver = $this->createMock(ProductExportStatusResolver::class);
+        $this->productActionResource = $this->createMock(ProductActionResource::class);
+        $this->subject = $this->createMock(ProductAction::class);
+
+        $this->plugin = new ProductActionUpdateAttributes(
+            $this->productExportStatusResolver,
+            $this->productActionResource
+        );
+    }
+
+    public function testAroundUpdateAttributesSkipsWhenStatusIsExplicitlyUpdated(): void
+    {
+        $proceedCalls = 0;
+        $proceed = function ($productIds, $attrData, $storeId) use (&$proceedCalls) {
+            $proceedCalls++;
+            return 'result';
+        };
+
+        $this->productExportStatusResolver
+            ->expects($this->never())
+            ->method('getProductIdsToSetPending');
+
+        $this->productActionResource
+            ->expects($this->never())
+            ->method('updateAttributes');
+
+        $result = $this->plugin->aroundUpdateAttributes(
+            $this->subject,
+            $proceed,
+            [10, 11],
+            ['orderflow_export_status' => 'Queued'],
+            2
+        );
+
+        $this->assertSame('result', $result);
+        $this->assertSame(1, $proceedCalls);
+    }
+
+    public function testAroundUpdateAttributesFlagsEligibleProductsPending(): void
+    {
+        $proceedCalls = 0;
+        $proceed = function ($productIds, $attrData, $storeId) use (&$proceedCalls) {
+            $proceedCalls++;
+            return 'result';
+        };
+
+        $this->productExportStatusResolver
+            ->expects($this->once())
+            ->method('getProductIdsToSetPending')
+            ->with([10, 11, 12])
+            ->willReturn([10, 12]);
+
+        $this->productActionResource
+            ->expects($this->once())
+            ->method('updateAttributes')
+            ->with(
+                [10, 12],
+                ['orderflow_export_status' => ProductExportStatusResolver::STATUS_PENDING],
+                Store::DEFAULT_STORE_ID
+            );
+
+        $result = $this->plugin->aroundUpdateAttributes(
+            $this->subject,
+            $proceed,
+            [10, 11, 12],
+            ['name' => 'Updated Name'],
+            2
+        );
+
+        $this->assertSame('result', $result);
+        $this->assertSame(1, $proceedCalls);
+    }
+
+    public function testAroundUpdateAttributesSkipsWhenNoEligibleProductsRemain(): void
+    {
+        $proceed = fn ($productIds, $attrData, $storeId) => 'result';
+
+        $this->productExportStatusResolver
+            ->expects($this->once())
+            ->method('getProductIdsToSetPending')
+            ->with([10, 11])
+            ->willReturn([]);
+
+        $this->productActionResource
+            ->expects($this->never())
+            ->method('updateAttributes');
+
+        $result = $this->plugin->aroundUpdateAttributes(
+            $this->subject,
+            $proceed,
+            [10, 11],
+            ['visibility' => 4],
+            0
+        );
+
+        $this->assertSame('result', $result);
+    }
+}

--- a/Test/Unit/Plugin/Catalog/ProductSaveTest.php
+++ b/Test/Unit/Plugin/Catalog/ProductSaveTest.php
@@ -20,7 +20,7 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
         $this->mockProduct = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
             ->disableOriginalConstructor()
             ->addMethods(['setOrderflowExportStatus'])
-            ->onlyMethods(['isDataChanged', 'dataHasChangedFor'])
+            ->onlyMethods(['isDataChanged', 'dataHasChangedFor', 'getData'])
             ->getMock();
 
         $this->mockProductResource = $this->createMock(\Magento\Catalog\Model\ResourceModel\Product::class);
@@ -50,8 +50,47 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
 
         $this->mockProduct
             ->expects($this->once())
+            ->method('dataHasChangedFor')
+            ->with('orderflow_export_status')
+            ->willReturn(false);
+
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('getData')
+            ->with('orderflow_export_status')
+            ->willReturn('Queued');
+
+        $this->mockProduct
+            ->expects($this->once())
             ->method('setOrderflowExportStatus')
             ->with('Pending');
+
+        $result = $this->plugin->beforeSave($this->mockProductResource, $this->mockProduct);
+        $this->assertEquals($this->mockProduct, $result[0]);
+    }
+
+    public function testBeforeSaveDisabledStatusPreserved(): void
+    {
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('isDataChanged')
+            ->willReturn(true);
+
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('dataHasChangedFor')
+            ->with('orderflow_export_status')
+            ->willReturn(false);
+
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('getData')
+            ->with('orderflow_export_status')
+            ->willReturn('Disabled');
+
+        $this->mockProduct
+            ->expects($this->never())
+            ->method('setOrderflowExportStatus');
 
         $result = $this->plugin->beforeSave($this->mockProductResource, $this->mockProduct);
         $this->assertEquals($this->mockProduct, $result[0]);

--- a/Test/Unit/Plugin/Catalog/ProductSaveTest.php
+++ b/Test/Unit/Plugin/Catalog/ProductSaveTest.php
@@ -5,6 +5,7 @@ namespace RealtimeDespatch\OrderFlow\Test\Unit\Plugin\Catalog;
 
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
 use RealtimeDespatch\OrderFlow\Plugin\Catalog\ProductSave;
 
 class ProductSaveTest extends \PHPUnit\Framework\TestCase
@@ -12,10 +13,12 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
     protected ProductSave $plugin;
     protected Product $mockProduct;
     protected ProductResource $mockProductResource;
+    protected ProductExportStatusResolver $productExportStatusResolver;
 
     protected function setUp(): void
     {
-        $this->plugin = new ProductSave();
+        $this->productExportStatusResolver = $this->createMock(ProductExportStatusResolver::class);
+        $this->plugin = new ProductSave($this->productExportStatusResolver);
 
         $this->mockProduct = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
             ->disableOriginalConstructor()
@@ -32,6 +35,10 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('isDataChanged')
             ->willReturn(false);
+
+        $this->productExportStatusResolver
+            ->expects($this->never())
+            ->method('shouldSetPending');
 
         $this->mockProduct
             ->expects($this->never())
@@ -50,15 +57,21 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
 
         $this->mockProduct
             ->expects($this->once())
+            ->method('getData')
+            ->with('orderflow_export_status')
+            ->willReturn('Queued');
+
+        $this->mockProduct
+            ->expects($this->once())
             ->method('dataHasChangedFor')
             ->with('orderflow_export_status')
             ->willReturn(false);
 
-        $this->mockProduct
+        $this->productExportStatusResolver
             ->expects($this->once())
-            ->method('getData')
-            ->with('orderflow_export_status')
-            ->willReturn('Queued');
+            ->method('shouldSetPending')
+            ->with('Queued', false)
+            ->willReturn(true);
 
         $this->mockProduct
             ->expects($this->once())
@@ -78,15 +91,21 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
 
         $this->mockProduct
             ->expects($this->once())
+            ->method('getData')
+            ->with('orderflow_export_status')
+            ->willReturn('Disabled');
+
+        $this->mockProduct
+            ->expects($this->once())
             ->method('dataHasChangedFor')
             ->with('orderflow_export_status')
             ->willReturn(false);
 
-        $this->mockProduct
+        $this->productExportStatusResolver
             ->expects($this->once())
-            ->method('getData')
-            ->with('orderflow_export_status')
-            ->willReturn('Disabled');
+            ->method('shouldSetPending')
+            ->with('Disabled', false)
+            ->willReturn(false);
 
         $this->mockProduct
             ->expects($this->never())
@@ -108,6 +127,18 @@ class ProductSaveTest extends \PHPUnit\Framework\TestCase
             ->method('dataHasChangedFor')
             ->with('orderflow_export_status')
             ->willReturn(true);
+
+        $this->mockProduct
+            ->expects($this->once())
+            ->method('getData')
+            ->with('orderflow_export_status')
+            ->willReturn('Queued');
+
+        $this->productExportStatusResolver
+            ->expects($this->once())
+            ->method('shouldSetPending')
+            ->with('Queued', true)
+            ->willReturn(false);
 
         $this->mockProduct
             ->expects($this->never())

--- a/Test/Unit/Plugin/ImportExport/ImportDataPluginTest.php
+++ b/Test/Unit/Plugin/ImportExport/ImportDataPluginTest.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace RealtimeDespatch\OrderFlow\Test\Unit\Plugin\ImportExport;
+
+use Magento\CatalogImportExport\Model\Import\Product as ProductImport;
+use Magento\ImportExport\Model\ResourceModel\Import\Data as ImportDataResource;
+use PHPUnit\Framework\TestCase;
+use RealtimeDespatch\OrderFlow\Model\Product\ExportStatus\ProductExportStatusResolver;
+use RealtimeDespatch\OrderFlow\Plugin\ImportExport\ImportDataPlugin;
+
+class ImportDataPluginTest extends TestCase
+{
+    private const ENTITY_TYPE_CODE = 'catalog_product';
+
+    private ProductExportStatusResolver $productExportStatusResolver;
+    private ImportDataPlugin $plugin;
+    private ImportDataResource $importDataResource;
+
+    protected function setUp(): void
+    {
+        $this->productExportStatusResolver = $this->createMock(ProductExportStatusResolver::class);
+        $this->plugin = new ImportDataPlugin($this->productExportStatusResolver);
+        $this->importDataResource = $this->createMock(ImportDataResource::class);
+    }
+
+    public function testAfterGetNextUniqueBunchSkipsNonProductImports(): void
+    {
+        $bunch = [[ProductImport::COL_SKU => 'ABC']];
+        $ids = [11, 12];
+
+        $this->importDataResource
+            ->expects($this->once())
+            ->method('getEntityTypeCode')
+            ->with($ids)
+            ->willReturn('customer_main');
+
+        $this->productExportStatusResolver
+            ->expects($this->never())
+            ->method('getSkusToSetPending');
+
+        $this->assertSame($bunch, $this->plugin->afterGetNextUniqueBunch($this->importDataResource, $bunch, $ids));
+    }
+
+    public function testAfterGetNextUniqueBunchAddsPendingForEligibleProducts(): void
+    {
+        $bunch = [
+            [ProductImport::COL_SKU => 'ABC', 'name' => 'Updated Product'],
+            ['description' => 'Continuation row'],
+            [ProductImport::COL_SKU => 'XYZ', 'orderflow_export_status' => 'Queued'],
+            [ProductImport::COL_SKU => 'NEW-SKU', 'price' => '9.99'],
+        ];
+        $ids = [21, 22];
+
+        $this->importDataResource
+            ->expects($this->once())
+            ->method('getEntityTypeCode')
+            ->with($ids)
+            ->willReturn(self::ENTITY_TYPE_CODE);
+
+        $this->productExportStatusResolver
+            ->expects($this->once())
+            ->method('getSkusToSetPending')
+            ->with(['ABC', 'NEW-SKU'])
+            ->willReturn(['ABC', 'NEW-SKU']);
+
+        $result = $this->plugin->afterGetNextUniqueBunch($this->importDataResource, $bunch, $ids);
+
+        $this->assertSame(ProductExportStatusResolver::STATUS_PENDING, $result[0]['orderflow_export_status']);
+        $this->assertSame(ProductExportStatusResolver::STATUS_PENDING, $result[1]['orderflow_export_status']);
+        $this->assertSame('Queued', $result[2]['orderflow_export_status']);
+        $this->assertSame(ProductExportStatusResolver::STATUS_PENDING, $result[3]['orderflow_export_status']);
+    }
+
+    public function testAfterGetNextUniqueBunchSkipsWhenNoEligibleProductsRemain(): void
+    {
+        $bunch = [
+            [ProductImport::COL_SKU => 'ABC'],
+        ];
+        $ids = [31];
+
+        $this->importDataResource
+            ->expects($this->once())
+            ->method('getEntityTypeCode')
+            ->with($ids)
+            ->willReturn(self::ENTITY_TYPE_CODE);
+
+        $this->productExportStatusResolver
+            ->expects($this->once())
+            ->method('getSkusToSetPending')
+            ->with(['ABC'])
+            ->willReturn([]);
+
+        $this->assertSame($bunch, $this->plugin->afterGetNextUniqueBunch($this->importDataResource, $bunch, $ids));
+    }
+
+    public function testAfterGetNextBunchDelegatesToSameLogic(): void
+    {
+        $bunch = [
+            [ProductImport::COL_SKU => 'ABC'],
+        ];
+
+        $this->importDataResource
+            ->expects($this->once())
+            ->method('getEntityTypeCode')
+            ->with(null)
+            ->willReturn(self::ENTITY_TYPE_CODE);
+
+        $this->productExportStatusResolver
+            ->expects($this->once())
+            ->method('getSkusToSetPending')
+            ->with(['ABC'])
+            ->willReturn(['ABC']);
+
+        $result = $this->plugin->afterGetNextBunch($this->importDataResource, $bunch);
+
+        $this->assertSame(ProductExportStatusResolver::STATUS_PENDING, $result[0]['orderflow_export_status']);
+    }
+}

--- a/Test/Unit/Plugin/Webapi/Soap/ProductExportTest.php
+++ b/Test/Unit/Plugin/Webapi/Soap/ProductExportTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Plugin\Webapi\Soap;
 
 use Magento\Framework\ObjectManagerInterface;
+use Magento\Webapi\Controller\Soap\Request\Handler as SoapRequestHandler;
 use RealtimeDespatch\OrderFlow\Api\RequestBuilderInterface;
+use RealtimeDespatch\OrderFlow\Helper\Export\Product as ProductHelper;
 use RealtimeDespatch\OrderFlow\Model\Service\Request\RequestProcessor;
 use RealtimeDespatch\OrderFlow\Plugin\Webapi\Soap\InventoryImport;
 use RealtimeDespatch\OrderFlow\Plugin\Webapi\Soap\ProductExport;
-use RealtimeDespatch\OrderFlow\Helper\Export\Product as ProductHelper;
-use Magento\Webapi\Controller\Soap\Request\Handler as SoapRequestHandler;
 
 class ProductExportTest extends \PHPUnit\Framework\TestCase
 {
@@ -21,7 +21,7 @@ class ProductExportTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->mockObjectManager = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
+        $this->mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $this->mockProductHelper = $this->createMock(ProductHelper::class);
         $this->mockRequestBuilder = $this->getMockBuilder(RequestBuilderInterface::class)
             ->disableOriginalConstructor()
@@ -39,9 +39,8 @@ class ProductExportTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider testAroundCallDataProvider
-     * @return void
      */
-    public function testAroundCall(bool $productExportEnabled): void
+    public function testAroundCall(string $operation, bool $productExportEnabled): void
     {
         $mockRequestProcessor = $this->createMock(RequestProcessor::class);
 
@@ -64,7 +63,7 @@ class ProductExportTest extends \PHPUnit\Framework\TestCase
             ->expects($this->once())
             ->method('setRequestBody');
 
-        $response = ['result' => 'success',];
+        $response = ['result' => 'success'];
 
         $this->mockRequestBuilder
             ->expects($this->once())
@@ -83,21 +82,21 @@ class ProductExportTest extends \PHPUnit\Framework\TestCase
             ->method('saveRequest')
             ->willReturn($mockRequest);
 
+        $this->mockProductHelper
+            ->expects($this->once())
+            ->method('isProductExportEnabledForProductWebsites')
+            ->with('SKU-1234')
+            ->willReturn($productExportEnabled);
+
         if (!$productExportEnabled) {
             $this->expectException(\Magento\Framework\Webapi\Exception::class);
             $this->expectExceptionMessage("Product 'SKU-1234' is not in any product export enabled websites");
-        } else {
-            $this->mockProductHelper
-                ->expects($this->once())
-                ->method('isProductExportEnabledForProductWebsites')
-                ->with('SKU-1234')
-                ->willReturn(true);
         }
 
         $this->plugin->around__call(
             $this->mockSoapRequestHandler,
             fn() => $response,
-            'catalogProductRepositoryV1Get',
+            $operation,
             [
                 (object) [
                     'sku' => 'SKU-1234',
@@ -113,9 +112,14 @@ class ProductExportTest extends \PHPUnit\Framework\TestCase
             ->method('create')
             ->with('ProductExportRequestProcessor');
 
+        $this->mockProductHelper
+            ->expects($this->never())
+            ->method('isProductExportEnabledForProductWebsites');
+
         $this->plugin->around__call(
             $this->mockSoapRequestHandler,
-            function() { },
+            function () {
+            },
             InventoryImport::class,
             [
                 (object) [
@@ -128,8 +132,10 @@ class ProductExportTest extends \PHPUnit\Framework\TestCase
     public function testAroundCallDataProvider(): array
     {
         return [
-            [true],
-            [false],
+            ['catalogProductRepositoryV1Get', true],
+            ['catalogProductRepositoryV1Get', false],
+            ['realtimeDespatchOrderFlowProductRepositoryV1Get', true],
+            ['realtimeDespatchOrderFlowProductRepositoryV1Get', false],
         ];
     }
 }

--- a/Test/Unit/bootstrap.php
+++ b/Test/Unit/bootstrap.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * PHPUnit bootstrap for running this module from either dev/ or vendor/.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Resolve the Magento project root by walking upward until the application bootstrap is found.
+ */
+$resolveMagentoRoot = static function (string $startDirectory): string {
+    $directory = $startDirectory;
+
+    while ($directory !== dirname($directory)) {
+        $autoloadPath = $directory . '/app/autoload.php';
+        $registrationPath = $directory . '/app/etc/NonComposerComponentRegistration.php';
+
+        if (is_readable($autoloadPath) && is_readable($registrationPath)) {
+            return $directory;
+        }
+
+        $directory = dirname($directory);
+    }
+
+    throw new RuntimeException('Unable to locate the Magento project root from the module test bootstrap.');
+};
+
+$magentoRoot = $resolveMagentoRoot(__DIR__);
+
+require_once $magentoRoot . '/app/autoload.php';
+
+if (!defined('TESTS_TEMP_DIR')) {
+    $testsTempDir = '/var/tmp/orderflow-unit';
+
+    if (!is_dir($testsTempDir) && !mkdir($testsTempDir, 0777, true) && !is_dir($testsTempDir)) {
+        throw new RuntimeException(sprintf('Unable to create the PHPUnit temp directory at "%s".', $testsTempDir));
+    }
+
+    define('TESTS_TEMP_DIR', $testsTempDir);
+}
+
+// PHP 8 compatibility. Define constants that are not present in PHP < 8.0.
+if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 80000) {
+    if (!defined('T_NAME_QUALIFIED')) {
+        define('T_NAME_QUALIFIED', 24001);
+    }
+    if (!defined('T_NAME_FULLY_QUALIFIED')) {
+        define('T_NAME_FULLY_QUALIFIED', 24002);
+    }
+}
+
+require_once $magentoRoot . '/vendor/magento/magento2-base/dev/tests/unit/framework/autoload.php';
+
+\Magento\Framework\Phrase::setRenderer(new \Magento\Framework\Phrase\Renderer\Placeholder());

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -99,6 +99,11 @@
                     <label>Store ID</label>
                     <source_model>Magento\Config\Model\Config\Source\Store</source_model>
                 </field>
+                <field id="use_attribute_option_labels" translate="label comment" type="select" sortOrder="5" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Use Attribute Option Labels</label>
+                    <comment>When enabled, product export responses return attribute option labels instead of stored option IDs for select and multiselect product attributes.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
         <section id="orderflow_inventory_import" translate="label" type="text" sortOrder="5000" showInDefault="1" showInWebsite="0" showInStore="0">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -30,6 +30,7 @@
                 <is_enabled>1</is_enabled>
                 <batch_size>100</batch_size>
                 <cron_expression>* * * * *</cron_expression>
+                <use_attribute_option_labels>0</use_attribute_option_labels>
             </settings>
         </orderflow_product_export>
         <orderflow_log_cleaning>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -241,6 +241,12 @@
     <type name="\Magento\Webapi\Controller\Soap\Request\Handler">
         <plugin name="orderflow_soap_inventory_import_request" type="RealtimeDespatch\OrderFlow\Plugin\Webapi\Soap\InventoryImport"/>
     </type>
+    <type name="Magento\ImportExport\Model\ResourceModel\Import\Data">
+        <plugin name="orderflow_product_export_status_import" type="RealtimeDespatch\OrderFlow\Plugin\ImportExport\ImportDataPlugin"/>
+    </type>
+    <type name="Magento\Catalog\Model\Product\Action">
+        <plugin name="orderflow_product_export_status_mass_update" type="RealtimeDespatch\OrderFlow\Plugin\Catalog\ProductActionUpdateAttributes"/>
+    </type>
     <virtualType name="orderflowLogger" type="Magento\Framework\Logger\Monolog">
         <arguments>
             <argument name="handlers"  xsi:type="array">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,6 +13,8 @@
     <preference for="RealtimeDespatch\OrderFlow\Api\InventoryRequestManagementInterface" type="RealtimeDespatch\OrderFlow\Model\Service\InventoryRequestService" />
     <preference for="RealtimeDespatch\OrderFlow\Api\OrderRequestManagementInterface" type="RealtimeDespatch\OrderFlow\Model\Service\OrderRequestService" />
     <preference for="RealtimeDespatch\OrderFlow\Api\ProductRequestManagementInterface" type="RealtimeDespatch\OrderFlow\Model\Service\ProductRequestService" />
+    <preference for="RealtimeDespatch\OrderFlow\Api\ProductRepositoryInterface" type="RealtimeDespatch\OrderFlow\Model\ProductRepository" />
+    <preference for="RealtimeDespatch\OrderFlow\Api\Data\ProductInterface" type="RealtimeDespatch\OrderFlow\Model\Data\Product" />
     <preference for="RealtimeDespatch\OrderFlow\Api\RequestBuilderInterface" type="RealtimeDespatch\OrderFlow\Model\Builder\RequestBuilder" />
     <preference for="RealtimeDespatch\OrderFlow\Api\Data\SequenceItemInterface" type="RealtimeDespatch\OrderFlow\Model\SequenceItem" />
     <preference for="RealtimeDespatch\OrderFlow\Api\Data\QuantityItemInterface" type="RealtimeDespatch\OrderFlow\Model\QuantityItem" />

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+    <route url="/V1/orderflow/product/:sku" method="GET">
+        <service class="RealtimeDespatch\OrderFlow\Api\ProductRepositoryInterface" method="get"/>
+        <resources>
+            <resource ref="Magento_Catalog::products" />
+        </resources>
+    </route>
     <!-- Products -->
     <route url="/V1/orderflow/export/product" method="POST">
         <service class="RealtimeDespatch\OrderFlow\Api\ProductRequestManagementInterface" method="export"/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,19 +10,19 @@
          colors="true"
          columns="max"
          beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="/var/www/html/dev/tests/unit/framework/bootstrap.php">
+         bootstrap="Test/Unit/bootstrap.php">
     <coverage>
         <include>
-            <directory suffix=".php">/var/www/html/vendor/realtimedespatch/magento2-orderflow/*</directory>
+            <directory suffix=".php">.</directory>
         </include>
         <exclude>
-            <directory suffix=".php">/var/www/html/vendor/realtimedespatch/magento2-orderflow/Test/*</directory>
+            <directory suffix=".php">Test</directory>
         </exclude>
     </coverage>
     <php>
         <includePath>.</includePath>
         <ini name="memory_limit" value="-1"/>
-        <ini name="date.timezone" value="America/Los_Angeles"/>
+        <ini name="date.timezone" value="Europe/London"/>
         <ini name="xdebug.max_nesting_level" value="200"/>
     </php>
     <listeners>


### PR DESCRIPTION
## Title

Make PHPUnit bootstrap relocatable

## Summary

This branch updates the module PHPUnit setup so the unit suite can run cleanly from a Composer-installed checkout without relying on hardcoded filesystem paths.

### What changed

- add a module-local `Test/Unit/bootstrap.php`
- resolve the real Magento project root dynamically by walking upward from the module
- load Magento from the real project root via `app/autoload.php`
- load Magento's unit-test generated-class autoloader from `vendor/magento/magento2-base/dev/tests/unit/framework/autoload.php`
- set `TESTS_TEMP_DIR` to `/var/tmp/orderflow-unit`
- update `phpunit.xml` to use the module-local bootstrap
- remove hardcoded `/var/www/html/...` paths from PHPUnit bootstrap and coverage config
- simplify coverage configuration to include the module root and exclude `Test`
- change the PHPUnit timezone setting to `Europe/London`

### Why

The previous PHPUnit configuration assumed a fixed `/var/www/html/...` layout and depended on a hardcoded Magento bootstrap path. That made the suite fail from this checkout even when the code itself was healthy.

By moving to a module-local bootstrap that discovers the Magento root dynamically, the test setup now works from the supported Composer-style layouts without encoding a specific absolute path.
