### PR TITLE
fix: return order export metadata in SOAP response

### DIFF
--- a/Plugin/Webapi/Soap/OrderExport.php
+++ b/Plugin/Webapi/Soap/OrderExport.php
@@ -2,6 +2,8 @@
 
 namespace RealtimeDespatch\OrderFlow\Plugin\Webapi\Soap;
 
+use RealtimeDespatch\OrderFlow\Api\RequestRepositoryInterface;
+
 class OrderExport
 {
     const OP_ORDER_EXPORT = 'salesOrderRepositoryV1Get';
@@ -22,19 +24,35 @@ class OrderExport
     protected $_orderRepository;
 
     /**
+     * @var \Magento\Sales\Model\OrderFactory
+     */
+    protected $_orderFactory;
+
+    /**
+     * @var RequestRepositoryInterface
+     */
+    protected $_requestRepository;
+
+    /**
      * OrderExport constructor.
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \RealtimeDespatch\OrderFlow\Api\RequestBuilderInterface $requestBuilder
      * @param \Magento\Sales\Model\OrderRepository $orderRepository
+     * @param \Magento\Sales\Model\OrderFactory $orderFactory
+     * @param RequestRepositoryInterface $requestRepository
      */
     public function __construct(
         \Magento\Framework\ObjectManagerInterface $objectManager,
         \RealtimeDespatch\OrderFlow\Api\RequestBuilderInterface $requestBuilder,
-        \Magento\Sales\Model\OrderRepository $orderRepository)
+        \Magento\Sales\Model\OrderRepository $orderRepository,
+        \Magento\Sales\Model\OrderFactory $orderFactory,
+        RequestRepositoryInterface $requestRepository)
     {
         $this->_objectManager = $objectManager;
         $this->_requestBuilder = $requestBuilder;
         $this->_orderRepository = $orderRepository;
+        $this->_orderFactory = $orderFactory;
+        $this->_requestRepository = $requestRepository;
     }
 
     public function around__call(\Magento\Webapi\Controller\Soap\Request\Handler $soapServer, callable $proceed, $operation, $arguments)
@@ -42,7 +60,11 @@ class OrderExport
         $result = $proceed($operation, $arguments);
 
         if ($this->_isOrderExport($operation) && isset($arguments[0]->id)) {
-            $this->_getRequestProcessor()->process($this->_buildOrderExportRequest($result['result'], $arguments[0]->id));
+            $request = $this->_buildOrderExportRequest($result['result'], $arguments[0]->id);
+            $this->_getRequestProcessor()->process($request);
+            $this->_applyExportStateToResult($result, $arguments[0]->id);
+            $request->setResponseBody(json_encode($result['result']));
+            $this->_requestRepository->save($request);
         }
 
         return $result;
@@ -94,5 +116,91 @@ class OrderExport
     protected function _getRequestProcessor()
     {
         return $this->_objectManager->create('OrderExportRequestProcessor');
+    }
+
+    /**
+     * Applies the persisted export metadata to the SOAP result before it is returned.
+     *
+     * @param array $result
+     * @param int|string $id
+     *
+     * @return void
+     */
+    protected function _applyExportStateToResult(array &$result, $id)
+    {
+        if ( ! isset($result['result'])) {
+            return;
+        }
+
+        $order = $this->_orderFactory->create()->load($id);
+
+        if ( ! $order->getId()) {
+            return;
+        }
+
+        $this->_setOrderflowExtensionAttribute(
+            $result['result'],
+            'orderflowExportStatus',
+            $order->getData('orderflow_export_status')
+        );
+        $this->_setOrderflowExtensionAttribute(
+            $result['result'],
+            'orderflowExportDate',
+            $order->getData('orderflow_export_date')
+        );
+    }
+
+    /**
+     * @param mixed $result
+     * @param string $key
+     * @param mixed $value
+     *
+     * @return void
+     */
+    protected function _setOrderflowExtensionAttribute(&$result, $key, $value)
+    {
+        if (is_object($result)) {
+            $extensionAttributes = $this->_getResultExtensionAttributes($result);
+            $setter = 'set'.ucfirst($key);
+
+            if (is_object($extensionAttributes) && method_exists($extensionAttributes, $setter)) {
+                $extensionAttributes->{$setter}($value);
+                return;
+            }
+
+            if ( ! is_object($extensionAttributes)) {
+                $extensionAttributes = new \stdClass();
+                $result->extensionAttributes = $extensionAttributes;
+            }
+
+            $extensionAttributes->{$key} = $value;
+            return;
+        }
+
+        if (is_array($result)) {
+            if ( ! isset($result['extensionAttributes']) || ! is_array($result['extensionAttributes'])) {
+                $result['extensionAttributes'] = [];
+            }
+
+            $result['extensionAttributes'][$key] = $value;
+        }
+    }
+
+    /**
+     * @param object $result
+     *
+     * @return mixed
+     */
+    protected function _getResultExtensionAttributes($result)
+    {
+        if (method_exists($result, 'getExtensionAttributes')) {
+            return $result->getExtensionAttributes();
+        }
+
+        if (isset($result->extensionAttributes)) {
+            return $result->extensionAttributes;
+        }
+
+        return null;
     }
 }

--- a/Test/Unit/Plugin/Webapi/Soap/OrderExportTest.php
+++ b/Test/Unit/Plugin/Webapi/Soap/OrderExportTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 namespace RealtimeDespatch\OrderFlow\Test\Unit\Plugin\Webapi\Soap;
 
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\OrderFactory;
 use Magento\Sales\Model\OrderRepository;
 use RealtimeDespatch\OrderFlow\Api\RequestBuilderInterface;
+use RealtimeDespatch\OrderFlow\Api\RequestRepositoryInterface;
 use RealtimeDespatch\OrderFlow\Plugin\Webapi\Soap\OrderExport;
 
 class OrderExportTest extends \PHPUnit\Framework\TestCase
@@ -14,6 +16,8 @@ class OrderExportTest extends \PHPUnit\Framework\TestCase
     protected \Magento\Framework\ObjectManagerInterface $mockObjectManager;
     protected RequestBuilderInterface $mockRequestBuilder;
     protected OrderRepositoryInterface $mockOrderRepository;
+    protected OrderFactory $mockOrderFactory;
+    protected RequestRepositoryInterface $mockRequestRepository;
 
     protected function setUp(): void
     {
@@ -24,18 +28,31 @@ class OrderExportTest extends \PHPUnit\Framework\TestCase
             ->onlyMethods(['saveRequest'])
             ->getMock();
         $this->mockOrderRepository = $this->createMock(OrderRepository::class);
+        $this->mockOrderFactory = $this->createMock(OrderFactory::class);
+        $this->mockRequestRepository = $this->createMock(RequestRepositoryInterface::class);
 
         $this->plugin = new OrderExport(
             $this->mockObjectManager,
             $this->mockRequestBuilder,
-            $this->mockOrderRepository
+            $this->mockOrderRepository,
+            $this->mockOrderFactory,
+            $this->mockRequestRepository
         );
     }
 
-    public function testAroundCall(): void
+    public function testAroundCallExportsAfterSuccessfulProceedAndUpdatesResponse(): void
     {
         $mockRequestProcessor = $this->createMock(\RealtimeDespatch\OrderFlow\Model\Service\Request\RequestProcessor::class);
         $mockOrder = $this->createMock(\Magento\Sales\Model\Order::class);
+        $freshOrder = $this->createMock(\Magento\Sales\Model\Order::class);
+        $mockRequest = $this->createMock(\RealtimeDespatch\OrderFlow\Model\Request::class);
+        $response = [
+            'result' => (object) [
+                'entityId' => 1,
+                'baseGrandTotal' => 100.00,
+            ],
+        ];
+        $proceeded = false;
 
         $this->mockObjectManager
             ->expects($this->once())
@@ -46,11 +63,7 @@ class OrderExportTest extends \PHPUnit\Framework\TestCase
         $this->mockRequestBuilder
             ->expects($this->once())
             ->method('setRequestData')
-            ->with(
-                'Export',
-                'Order',
-                'Export',
-            )
+            ->with('Export', 'Order', 'Export')
             ->willReturnSelf();
 
         $this->mockRequestBuilder
@@ -58,7 +71,17 @@ class OrderExportTest extends \PHPUnit\Framework\TestCase
             ->method('setRequestBody')
             ->willReturnSelf();
 
-        $mockRequest = $this->createMock(\RealtimeDespatch\OrderFlow\Model\Request::class);
+        $this->mockRequestBuilder
+            ->expects($this->once())
+            ->method('setResponseBody')
+            ->with(json_encode($response['result']))
+            ->willReturnSelf();
+
+        $this->mockRequestBuilder
+            ->expects($this->once())
+            ->method('addRequestLine')
+            ->with(json_encode(['increment_id' => '100000001']))
+            ->willReturnSelf();
 
         $this->mockRequestBuilder
             ->expects($this->once())
@@ -71,10 +94,65 @@ class OrderExportTest extends \PHPUnit\Framework\TestCase
             ->with(1)
             ->willReturn($mockOrder);
 
+        $mockOrder
+            ->expects($this->once())
+            ->method('getIncrementId')
+            ->willReturn('100000001');
+
+        $mockRequestProcessor
+            ->expects($this->once())
+            ->method('process')
+            ->with($mockRequest)
+            ->willReturnCallback(function () use (&$proceeded) {
+                $this->assertTrue($proceeded);
+            });
+
+        $this->mockOrderFactory
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn($freshOrder);
+
+        $freshOrder
+            ->expects($this->once())
+            ->method('load')
+            ->with(1)
+            ->willReturnSelf();
+
+        $freshOrder
+            ->expects($this->once())
+            ->method('getId')
+            ->willReturn(1);
+
+        $freshOrder
+            ->expects($this->exactly(2))
+            ->method('getData')
+            ->willReturnMap([
+                ['orderflow_export_status', null, 'Exported'],
+                ['orderflow_export_date', null, '2026-05-19 10:15:00'],
+            ]);
+
+        $mockRequest
+            ->expects($this->once())
+            ->method('setResponseBody')
+            ->with($this->callback(function ($body) {
+                $decoded = json_decode($body, true);
+
+                return ($decoded['extensionAttributes']['orderflowExportStatus'] ?? null) === 'Exported'
+                    && ($decoded['extensionAttributes']['orderflowExportDate'] ?? null) === '2026-05-19 10:15:00';
+            }))
+            ->willReturnSelf();
+
+        $this->mockRequestRepository
+            ->expects($this->once())
+            ->method('save')
+            ->with($mockRequest)
+            ->willReturn($mockRequest);
+
         $result = $this->plugin->around__call(
             $this->createMock(\Magento\Webapi\Controller\Soap\Request\Handler::class),
-            function() {
-                return ['result' => 'success'];
+            function () use (&$proceeded, $response) {
+                $proceeded = true;
+                return $response;
             },
             'salesOrderRepositoryV1Get',
             [
@@ -82,7 +160,48 @@ class OrderExportTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $this->assertEquals(['result' => 'success'], $result);
+        $this->assertSame('Exported', $result['result']->extensionAttributes->orderflowExportStatus);
+        $this->assertSame('2026-05-19 10:15:00', $result['result']->extensionAttributes->orderflowExportDate);
     }
 
+    public function testAroundCallDoesNotExportWhenProceedFails(): void
+    {
+        $this->mockObjectManager
+            ->expects($this->never())
+            ->method('create');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('SOAP failure');
+
+        $this->plugin->around__call(
+            $this->createMock(\Magento\Webapi\Controller\Soap\Request\Handler::class),
+            function () {
+                throw new \RuntimeException('SOAP failure');
+            },
+            'salesOrderRepositoryV1Get',
+            [
+                (object) ['id' => 1]
+            ]
+        );
+    }
+
+    public function testAroundCallLeavesNonOrderExportOperationsUnchanged(): void
+    {
+        $this->mockObjectManager
+            ->expects($this->never())
+            ->method('create');
+
+        $result = $this->plugin->around__call(
+            $this->createMock(\Magento\Webapi\Controller\Soap\Request\Handler::class),
+            function () {
+                return ['result' => 'success'];
+            },
+            'catalogProductRepositoryV1Get',
+            [
+                (object) ['sku' => 'ABC']
+            ]
+        );
+
+        $this->assertEquals(['result' => 'success'], $result);
+    }
 }


### PR DESCRIPTION
- mark orders exported only after successful SOAP retrieval
- refresh the returned SOAP payload with persisted export status and date
- cover success, failure, and non-order SOAP paths in unit tests

AI-Generated: Codex